### PR TITLE
Ajout de mini_racer.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,7 @@ gem 'bootsnap', '>= 1.1.0', require: false
 gem 'devise'
 gem 'pg', '~> 0.18'
 gem 'rack-cors', require: 'rack/cors'
+gem 'mini_racer', '~> 0.2.0'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -150,6 +150,7 @@ GEM
     kaminari-core (1.1.1)
     launchy (2.4.3)
       addressable (~> 2.3)
+    libv8 (6.7.288.46.1)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -166,6 +167,8 @@ GEM
     mimemagic (0.3.3)
     mini_mime (1.0.1)
     mini_portile2 (2.4.0)
+    mini_racer (0.2.4)
+      libv8 (>= 6.3)
     minitest (5.11.3)
     msgpack (1.2.6)
     nenv (0.3.0)
@@ -308,6 +311,7 @@ DEPENDENCIES
   guard-rubocop
   launchy
   listen (>= 3.0.5, < 3.2)
+  mini_racer (~> 0.2.0)
   pg (~> 0.18)
   puma (~> 3.11)
   rack-cors


### PR DESCRIPTION
Si on lance le serveur dans un container docker "ruby", nous avons une
erreur au lancement car il n'y a aucun runtime javascript
installé. Ajouté la gem mini_racer rêgle ce problème. Et je crois que si
node est installé il est préféré.