### PR TITLE
Ajoute le dockerfile de "production" pour déployer l'api

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@
 /config/master.key
 
 .ruby-version
+
+# Ignore locally installed gems
+/vendor/ruby

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM ruby:2.6
+
+ARG RAILS_ENV
+ENV RAILS_ENV ${RAILS_ENV}
+
+WORKDIR /app/
+
+COPY Gemfile Gemfile.lock ./
+RUN bundle install --without development test --deployment --jobs 4 --retry 3 --quiet
+
+COPY . ./
+
+RUN bundle exec rails assets:precompile RAILS_ENV=${RAILS_ENV} SECRET_KEY_BASE=ceci-est-une-fausse-secret-key-pour-que-rails-accepte-de-demarrer
+
+EXPOSE 3000
+
+CMD ["bundle", "exec", "rails", "server"]


### PR DESCRIPTION
Le dockerfile contient tout ce qu'il faut pour construire l'application rails et la servir.

Je n'ai pas mis de documentation particulière car ce sera au niveau de l'orchestrateur, mais je peux le faire.