### PR TITLE
Restitution de la situation inventaire

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -17,6 +17,7 @@ Metrics/LineLength:
 Metrics/BlockLength:
   Exclude:
     - 'app/views/**/*'
+    - 'spec/factories/*'
     - 'Guardfile'
   ExcludedMethods:
     - describe

--- a/app/admin/evaluations.rb
+++ b/app/admin/evaluations.rb
@@ -1,4 +1,3 @@
-# rubocop:disable Metrics/BlockLength
 ActiveAdmin.register Evenement, as: 'Evaluations' do
   config.sort_order = 'date_desc'
   actions :index, :show
@@ -32,4 +31,3 @@ ActiveAdmin.register Evenement, as: 'Evaluations' do
     render 'evaluation_sidebar', evaluation: resource
   end
 end
-# rubocop:enable Metrics/BlockLength

--- a/app/admin/evaluations.rb
+++ b/app/admin/evaluations.rb
@@ -1,0 +1,90 @@
+# rubocop:disable Metrics/BlockLength
+ActiveAdmin.register Evenement, as: 'Evaluations' do
+  config.sort_order = 'date_desc'
+  actions :index, :show
+
+  controller do
+    def scoped_collection
+      end_of_association_chain.where(nom: 'demarrage')
+    end
+
+    def find_resource
+      EvaluationInventaire.new(
+        Evenement.where(session_id: params[:id]).order(:date)
+      )
+    end
+  end
+
+  index do
+    column :situation
+    column :session_id
+    column :date
+    column '' do |evenement|
+      link_to t('.rapport'), admin_evaluation_path(id: evenement.session_id)
+    end
+  end
+
+  show title: :session_id do
+    evaluation = resource
+    table do
+      thead do
+        tr do
+          th
+          evaluation.essais.each_with_index do |essai, index|
+            if essai.abandon? || essai.en_cours?
+              th
+            else
+              th t('.essai', count: index + 1)
+            end
+          end
+        end
+      end
+      tr do
+        th t('.etat')
+        evaluation.essais.each do |essai|
+          td do
+            if essai.reussite?
+              status_tag t('.reussite'), class: 'green'
+            elsif essai.abandon?
+              status_tag t('.abandon'), class: 'red'
+            elsif essai.en_cours?
+              status_tag t('.en_cours')
+            else
+              status_tag t('.echec'), class: 'red'
+            end
+          end
+        end
+      end
+      tr do
+        th t('.temps')
+        evaluation.essais.each do |essai|
+          td "+#{distance_of_time_in_words(essai.temps_total)}"
+        end
+      end
+      tr do
+        th t('.ouverture_contenant')
+        evaluation.essais.each do |essai|
+          td essai.nombre_ouverture_contenant
+        end
+      end
+    end
+  end
+
+  sidebar :info, only: :show do
+    attributes_table_for resource do
+      row(t('.etat')) do |evaluation|
+        if evaluation.reussite?
+          status_tag t('.reussite'), class: 'green'
+        elsif evaluation.abandon?
+          status_tag t('.abandon'), class: 'red'
+        else
+          status_tag t('.en_cours')
+        end
+      end
+      row(t('.temps')) { |evaluation| distance_of_time_in_words(evaluation.temps_total) }
+      row :nombre_ouverture_contenant
+      row :nombre_essais_validation
+    end
+  end
+end
+# rubocop:enable Metrics/BlockLength

--- a/app/admin/evaluations.rb
+++ b/app/admin/evaluations.rb
@@ -25,66 +25,11 @@ ActiveAdmin.register Evenement, as: 'Evaluations' do
   end
 
   show title: :session_id do
-    evaluation = resource
-    table do
-      thead do
-        tr do
-          th
-          evaluation.essais.each_with_index do |essai, index|
-            if essai.abandon? || essai.en_cours?
-              th
-            else
-              th t('.essai', count: index + 1)
-            end
-          end
-        end
-      end
-      tr do
-        th t('.etat')
-        evaluation.essais.each do |essai|
-          td do
-            if essai.reussite?
-              status_tag t('.reussite'), class: 'green'
-            elsif essai.abandon?
-              status_tag t('.abandon'), class: 'red'
-            elsif essai.en_cours?
-              status_tag t('.en_cours')
-            else
-              status_tag t('.echec'), class: 'red'
-            end
-          end
-        end
-      end
-      tr do
-        th t('.temps')
-        evaluation.essais.each do |essai|
-          td "+#{distance_of_time_in_words(essai.temps_total)}"
-        end
-      end
-      tr do
-        th t('.ouverture_contenant')
-        evaluation.essais.each do |essai|
-          td essai.nombre_ouverture_contenant
-        end
-      end
-    end
+    render 'evaluation', evaluation: resource
   end
 
   sidebar :info, only: :show do
-    attributes_table_for resource do
-      row(t('.etat')) do |evaluation|
-        if evaluation.reussite?
-          status_tag t('.reussite'), class: 'green'
-        elsif evaluation.abandon?
-          status_tag t('.abandon'), class: 'red'
-        else
-          status_tag t('.en_cours')
-        end
-      end
-      row(t('.temps')) { |evaluation| distance_of_time_in_words(evaluation.temps_total) }
-      row :nombre_ouverture_contenant
-      row :nombre_essais_validation
-    end
+    render 'evaluation_sidebar', evaluation: resource
   end
 end
 # rubocop:enable Metrics/BlockLength

--- a/app/models/evaluation_inventaire.rb
+++ b/app/models/evaluation_inventaire.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+class EvaluationInventaire
+  EVENEMENT = {
+    OUVERTURE_CONTENANT: 'ouvertureContenant',
+    SAISIE_INVENTAIRE: 'saisieInventaire',
+    STOP: 'stop'
+  }.freeze
+
+  module Evaluation
+    def reussite?
+      @evenements.last.nom == EVENEMENT[:SAISIE_INVENTAIRE] &&
+        @evenements.last.donnees['reussite']
+    end
+
+    def en_cours?
+      @evenements.last.nom != EVENEMENT[:SAISIE_INVENTAIRE] &&
+        @evenements.last.nom != EVENEMENT[:STOP]
+    end
+
+    def abandon?
+      @evenements.last.nom == EVENEMENT[:STOP]
+    end
+
+    def nombre_ouverture_contenant
+      compte_nom_evenements(@evenements, EVENEMENT[:OUVERTURE_CONTENANT])
+    end
+
+    def nombre_essais_validation
+      compte_nom_evenements(@evenements, EVENEMENT[:SAISIE_INVENTAIRE])
+    end
+
+    def compte_nom_evenements(evenements, nom)
+      evenements.reduce(0) do |nombre, evenement|
+        if evenement.nom == nom
+          nombre + 1
+        else
+          nombre
+        end
+      end
+    end
+  end
+  include Evaluation
+
+  class Essai
+    include Evaluation
+
+    def initialize(evenements, date_depart_situation)
+      @evenements = evenements
+      @date_depart_situation = date_depart_situation
+    end
+
+    def temps_total
+      @evenements.last.date - @date_depart_situation
+    end
+  end
+
+  def initialize(evenements)
+    @evenements = evenements
+  end
+
+  def session_id
+    @evenements.first.session_id
+  end
+
+  def temps_total
+    @evenements.last.date - @evenements.first.date
+  end
+
+  def essais
+    essais = @evenements.chunk_while do |evenement_avant, _|
+      evenement_avant.nom != EVENEMENT[:SAISIE_INVENTAIRE]
+    end
+    date_depart = @evenements.first.date
+    essais.map do |evenements|
+      cree_essai(evenements, date_depart)
+    end
+  end
+
+  private
+
+  def cree_essai(evenements, date_depart)
+    Essai.new(
+      evenements,
+      date_depart
+    )
+  end
+end

--- a/app/views/admin/evaluations/_evaluation.html.arb
+++ b/app/views/admin/evaluations/_evaluation.html.arb
@@ -1,0 +1,42 @@
+table do
+  thead do
+    tr do
+      th
+      evaluation.essais.each_with_index do |essai, index|
+        if essai.abandon? || essai.en_cours?
+          th
+        else
+          th t('.essai', count: index + 1)
+        end
+      end
+    end
+  end
+  tr do
+    th t('.etat')
+    evaluation.essais.each do |essai|
+      td do
+        if essai.reussite?
+          status_tag t('.reussite'), class: 'green'
+        elsif essai.abandon?
+          status_tag t('.abandon'), class: 'red'
+        elsif essai.en_cours?
+          status_tag t('.en_cours')
+        else
+          status_tag t('.echec'), class: 'red'
+        end
+      end
+    end
+  end
+  tr do
+    th t('.temps')
+    evaluation.essais.each do |essai|
+      td "+#{distance_of_time_in_words(essai.temps_total)}"
+    end
+  end
+  tr do
+    th t('.ouverture_contenant')
+    evaluation.essais.each do |essai|
+      td essai.nombre_ouverture_contenant
+    end
+  end
+end

--- a/app/views/admin/evaluations/_evaluation_sidebar.html.arb
+++ b/app/views/admin/evaluations/_evaluation_sidebar.html.arb
@@ -1,0 +1,14 @@
+attributes_table_for resource do
+  row(t('admin.evaluations.evaluation.etat')) do |evaluation|
+    if evaluation.reussite?
+      status_tag t('admin.evaluations.evaluation.reussite'), class: 'green'
+    elsif evaluation.abandon?
+      status_tag t('admin.evaluations.evaluation.abandon'), class: 'red'
+    else
+      status_tag t('admin.evaluations.evaluation.en_cours')
+    end
+  end
+  row(t('admin.evaluations.evaluation.temps')) { |evaluation| distance_of_time_in_words(evaluation.temps_total) }
+  row :nombre_ouverture_contenant
+  row :nombre_essais_validation
+end

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -217,3 +217,16 @@ fr:
       long: "%A %d %B %Y %Hh%M"
       short: "%d %b %Hh%M"
     pm: pm
+  active_admin:
+    resource:
+      index:
+        rapport: Rapport
+      show:
+        essai: Essai %{count}
+        reussite: Réussite
+        abandon: Abandon
+        en_cours: En cours
+        echec: Échec
+        temps: Temps
+        ouverture_contenant: Ouverture de contenant
+        etat: État

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -221,7 +221,9 @@ fr:
     resource:
       index:
         rapport: Rapport
-      show:
+  admin:
+    evaluations:
+      evaluation:
         essai: Essai %{count}
         reussite: Réussite
         abandon: Abandon

--- a/spec/factories/evenement.rb
+++ b/spec/factories/evenement.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-# rubocop:disable Metrics/BlockLength
 FactoryBot.define do
   factory :evenement do
     nom { 'ouvertureContenant' }
@@ -42,4 +41,3 @@ FactoryBot.define do
     end
   end
 end
-# rubocop:enable Metrics/BlockLength

--- a/spec/factories/evenement.rb
+++ b/spec/factories/evenement.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+# rubocop:disable Metrics/BlockLength
 FactoryBot.define do
   factory :evenement do
     nom { 'ouvertureContenant' }
@@ -7,5 +8,38 @@ FactoryBot.define do
     situation { 'inventaire' }
     session_id { '07319b2485be9ac4850664cd47cede38' }
     date { DateTime.now }
+
+    factory :evenement_demarrage do
+      nom { 'demarrage' }
+      donnees { {} }
+    end
+
+    factory :evenement_saisie_inventaire do
+      nom { 'saisieInventaire' }
+      donnees { {} }
+
+      factory :evenement_saisie_inventaire_ok do
+        donnees do
+          { reussite: true }
+        end
+      end
+
+      factory :evenement_saisie_inventaire_echec do
+        donnees do
+          { reussite: false }
+        end
+      end
+    end
+
+    factory :evenement_ouverture_contenant do
+      nom { 'ouvertureContenant' }
+      donnees { { contenant: 1 } }
+    end
+
+    factory :evenement_stop do
+      nom { 'stop' }
+      donnees { {} }
+    end
   end
 end
+# rubocop:enable Metrics/BlockLength

--- a/spec/factories/evenement.rb
+++ b/spec/factories/evenement.rb
@@ -17,13 +17,13 @@ FactoryBot.define do
       nom { 'saisieInventaire' }
       donnees { {} }
 
-      factory :evenement_saisie_inventaire_ok do
+      trait :ok do
         donnees do
           { reussite: true }
         end
       end
 
-      factory :evenement_saisie_inventaire_echec do
+      trait :echec do
         donnees do
           { reussite: false }
         end

--- a/spec/models/evaluation_inventaire_spec.rb
+++ b/spec/models/evaluation_inventaire_spec.rb
@@ -1,0 +1,118 @@
+require 'rails_helper'
+
+describe EvaluationInventaire do
+  describe EvaluationInventaire::Essai do
+    it 'retourne le temps depuis le début de la situation' do
+      evenements = [
+        build(:evenement_ouverture_contenant, date: 2.minute.ago),
+        build(:evenement_ouverture_contenant, date: 1.minute.ago)
+      ]
+      evaluation = described_class.new(evenements, 5.minute.ago)
+      expect(evaluation.temps_total).to be_within(0.1).of(240)
+    end
+  end
+
+  it 'session_id retourne le session_id' do
+    evenements = [
+      build(:evenement_demarrage, session_id: 'exemple')
+    ]
+    evaluation = described_class.new(evenements)
+    expect(evaluation.session_id).to eql('exemple')
+  end
+
+  it 'est en reussite' do
+    evenements = [
+      build(:evenement_demarrage),
+      build(:evenement_saisie_inventaire_ok)
+    ]
+    evaluation = described_class.new(evenements)
+    expect(evaluation).to be_reussite
+    expect(evaluation).to_not be_abandon
+    expect(evaluation).to_not be_en_cours
+  end
+
+  it 'est en echec' do
+    evenements = [
+      build(:evenement_demarrage),
+      build(:evenement_saisie_inventaire_echec)
+    ]
+    evaluation = described_class.new(evenements)
+    expect(evaluation).to_not be_reussite
+    expect(evaluation).to_not be_abandon
+    expect(evaluation).to_not be_en_cours
+  end
+
+  it 'est en abandon' do
+    evenements = [
+      build(:evenement_demarrage),
+      build(:evenement_stop)
+    ]
+    evaluation = described_class.new(evenements)
+    expect(evaluation).to_not be_reussite
+    expect(evaluation).to be_abandon
+    expect(evaluation).to_not be_en_cours
+  end
+
+  it 'est en cours' do
+    evenements = [
+      build(:evenement_demarrage)
+    ]
+    evaluation = described_class.new(evenements)
+    expect(evaluation).to_not be_reussite
+    expect(evaluation).to_not be_abandon
+    expect(evaluation).to be_en_cours
+  end
+
+  it 'retourne le temps total' do
+    evenements = [
+      build(:evenement_demarrage, date: 10.minutes.ago),
+      build(:evenement_saisie_inventaire_ok, date: 4.minutes.ago)
+    ]
+    evaluation = described_class.new(evenements)
+    expect(evaluation.temps_total).to be_within(0.1).of(360)
+  end
+
+  it "retourne le nombre d'ouverture de contenant" do
+    evenements = [
+      build(:evenement_ouverture_contenant),
+      build(:evenement_ouverture_contenant),
+      build(:evenement_ouverture_contenant)
+    ]
+    evaluation = described_class.new(evenements)
+    expect(evaluation.nombre_ouverture_contenant).to eql(3)
+  end
+
+  it "retourne le nombre d'essai de validation" do
+    evenements = [
+      build(:evenement_saisie_inventaire_echec),
+      build(:evenement_saisie_inventaire_echec),
+      build(:evenement_saisie_inventaire_echec),
+      build(:evenement_saisie_inventaire_ok)
+    ]
+    evaluation = described_class.new(evenements)
+    expect(evaluation.nombre_essais_validation).to eql(4)
+  end
+
+  it 'retourne les essais avec le nombre de click et le temps' do
+    evenements = [
+      build(:evenement_demarrage, date: 10.minutes.ago),
+      build(:evenement_ouverture_contenant, date: 8.minutes.ago),
+      build(:evenement_ouverture_contenant, date: 8.minutes.ago),
+      build(:evenement_ouverture_contenant, date: 8.minutes.ago),
+      build(:evenement_saisie_inventaire_echec, date: 7.minutes.ago),
+      build(:evenement_saisie_inventaire_ok, date: 5.minutes.ago)
+    ]
+    evaluation = described_class.new(evenements)
+    expect(evaluation.essais.size).to eql(2)
+    evaluation.essais.first.tap do |essai|
+      expect(essai).to_not be_reussite
+      expect(essai.nombre_ouverture_contenant).to eql(3)
+      expect(essai.temps_total).to within(0.1).of(180)
+    end
+    evaluation.essais.last.tap do |essai|
+      expect(essai).to be_reussite
+      expect(essai.nombre_ouverture_contenant).to eql(0)
+      expect(essai.temps_total).to within(0.1).of(300)
+    end
+  end
+end

--- a/spec/models/evaluation_inventaire_spec.rb
+++ b/spec/models/evaluation_inventaire_spec.rb
@@ -23,7 +23,7 @@ describe EvaluationInventaire do
   it 'est en reussite' do
     evenements = [
       build(:evenement_demarrage),
-      build(:evenement_saisie_inventaire_ok)
+      build(:evenement_saisie_inventaire, :ok)
     ]
     evaluation = described_class.new(evenements)
     expect(evaluation).to be_reussite
@@ -34,7 +34,7 @@ describe EvaluationInventaire do
   it 'est en echec' do
     evenements = [
       build(:evenement_demarrage),
-      build(:evenement_saisie_inventaire_echec)
+      build(:evenement_saisie_inventaire, :echec)
     ]
     evaluation = described_class.new(evenements)
     expect(evaluation).to_not be_reussite
@@ -66,7 +66,7 @@ describe EvaluationInventaire do
   it 'retourne le temps total' do
     evenements = [
       build(:evenement_demarrage, date: 10.minutes.ago),
-      build(:evenement_saisie_inventaire_ok, date: 4.minutes.ago)
+      build(:evenement_saisie_inventaire, :ok, date: 4.minutes.ago)
     ]
     evaluation = described_class.new(evenements)
     expect(evaluation.temps_total).to be_within(0.1).of(360)
@@ -84,10 +84,10 @@ describe EvaluationInventaire do
 
   it "retourne le nombre d'essai de validation" do
     evenements = [
-      build(:evenement_saisie_inventaire_echec),
-      build(:evenement_saisie_inventaire_echec),
-      build(:evenement_saisie_inventaire_echec),
-      build(:evenement_saisie_inventaire_ok)
+      build(:evenement_saisie_inventaire, :echec),
+      build(:evenement_saisie_inventaire, :echec),
+      build(:evenement_saisie_inventaire, :echec),
+      build(:evenement_saisie_inventaire, :ok)
     ]
     evaluation = described_class.new(evenements)
     expect(evaluation.nombre_essais_validation).to eql(4)
@@ -99,8 +99,8 @@ describe EvaluationInventaire do
       build(:evenement_ouverture_contenant, date: 8.minutes.ago),
       build(:evenement_ouverture_contenant, date: 8.minutes.ago),
       build(:evenement_ouverture_contenant, date: 8.minutes.ago),
-      build(:evenement_saisie_inventaire_echec, date: 7.minutes.ago),
-      build(:evenement_saisie_inventaire_ok, date: 5.minutes.ago)
+      build(:evenement_saisie_inventaire, :echec, date: 7.minutes.ago),
+      build(:evenement_saisie_inventaire, :ok, date: 5.minutes.ago)
     ]
     evaluation = described_class.new(evenements)
     expect(evaluation.essais.size).to eql(2)


### PR DESCRIPTION
J'ai commencé une page de restitutions des évaluations.

Une nouvelle page sur Active Admin fait sont apparition "Évaluations" qui liste toute les évaluations :
![Screenshot_2019-04-01 Evaluations Competences Pro Serveur](https://user-images.githubusercontent.com/86659/55355641-31ab9980-54c9-11e9-9b9b-37de517ff148.png)

Sur la page de l'évaluation, nous avons un tableau qui liste les différent essais avec le temps passé depuis le début, le nombre d'ouverture de contenant entre les essais, et l'état: échec, réussite ou en cours. 
Une sidebar permet d'afficher des informations globale sur l'évaluation.
![Screenshot_2019-04-01 e582b4d2-87e2-4572-b38c-aad821b1cd0c Competences Pro Serveur](https://user-images.githubusercontent.com/86659/55355640-31ab9980-54c9-11e9-8469-b8a837542eb3.png)