### PR TITLE
Controle: affiche l'état de la situation

### DIFF
--- a/app/models/evaluation_base.rb
+++ b/app/models/evaluation_base.rb
@@ -26,4 +26,8 @@ class EvaluationBase
   def abandon?
     @evenements.last.nom == EVENEMENT[:STOP]
   end
+
+  def termine?
+    raise NotImplementedError
+  end
 end

--- a/app/models/evaluation_base.rb
+++ b/app/models/evaluation_base.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 
 class EvaluationBase
+  EVENEMENT = {
+    STOP: 'stop'
+  }.freeze
+
   delegate :session_id, :utilisateur, :situation, :date, to: :premier_evenement
 
   def initialize(evenements)
@@ -17,5 +21,9 @@ class EvaluationBase
 
   def premier_evenement
     @evenements.first
+  end
+
+  def abandon?
+    @evenements.last.nom == EVENEMENT[:STOP]
   end
 end

--- a/app/models/evaluation_controle.rb
+++ b/app/models/evaluation_controle.rb
@@ -1,11 +1,17 @@
 # frozen_string_literal: true
 
 class EvaluationControle < EvaluationBase
+  PIECES_TOTAL = 60
+
   EVENEMENT = {
     PIECE_BIEN_PLACEE: 'pieceBienPlacee',
     PIECE_MAL_PLACEE: 'pieceMalPlacee',
     PIECE_RATEE: 'pieceRatee'
   }.freeze
+
+  def termine?
+    evenements_pieces.count == PIECES_TOTAL
+  end
 
   def nombre_bien_placees
     compte_nom_evenements EVENEMENT[:PIECE_BIEN_PLACEE]

--- a/app/models/evaluation_controle.rb
+++ b/app/models/evaluation_controle.rb
@@ -18,4 +18,10 @@ class EvaluationControle < EvaluationBase
   def nombre_ratees
     compte_nom_evenements EVENEMENT[:PIECE_RATEE]
   end
+
+  def evenements_pieces
+    noms_evenements_pieces =
+      EVENEMENT.slice(:PIECE_BIEN_PLACEE, :PIECE_MAL_PLACEE, :PIECE_RATEE).values
+    @evenements.find_all { |e| noms_evenements_pieces.include?(e.nom) }
+  end
 end

--- a/app/models/evaluation_inventaire.rb
+++ b/app/models/evaluation_inventaire.rb
@@ -21,6 +21,7 @@ class EvaluationInventaire < EvaluationBase
     @evenements.last.nom == EVENEMENT[:SAISIE_INVENTAIRE] &&
       @evenements.last.donnees['reussite']
   end
+  alias termine? reussite?
 
   def en_cours?
     @evenements.last.nom != EVENEMENT[:SAISIE_INVENTAIRE] && !abandon?

--- a/app/models/evaluation_inventaire.rb
+++ b/app/models/evaluation_inventaire.rb
@@ -3,8 +3,7 @@
 class EvaluationInventaire < EvaluationBase
   EVENEMENT = {
     OUVERTURE_CONTENANT: 'ouvertureContenant',
-    SAISIE_INVENTAIRE: 'saisieInventaire',
-    STOP: 'stop'
+    SAISIE_INVENTAIRE: 'saisieInventaire'
   }.freeze
 
   class Essai < EvaluationInventaire
@@ -24,12 +23,7 @@ class EvaluationInventaire < EvaluationBase
   end
 
   def en_cours?
-    @evenements.last.nom != EVENEMENT[:SAISIE_INVENTAIRE] &&
-      @evenements.last.nom != EVENEMENT[:STOP]
-  end
-
-  def abandon?
-    @evenements.last.nom == EVENEMENT[:STOP]
+    @evenements.last.nom != EVENEMENT[:SAISIE_INVENTAIRE] && !abandon?
   end
 
   def nombre_ouverture_contenant

--- a/app/views/admin/evaluations/_evaluation_inventaire.html.arb
+++ b/app/views/admin/evaluations/_evaluation_inventaire.html.arb
@@ -2,15 +2,6 @@
 
 panel t('.informations_specifiques') do
   attributes_table_for resource do
-    row(t('admin.evaluations.evaluation.etat')) do |evaluation|
-      if evaluation.reussite?
-        status_tag t('admin.evaluations.evaluation.reussite'), class: 'green'
-      elsif evaluation.abandon?
-        status_tag t('admin.evaluations.evaluation.abandon'), class: 'red'
-      else
-        status_tag t('admin.evaluations.evaluation.en_cours')
-      end
-    end
     row t('.ouverture_contenant'), &:nombre_ouverture_contenant
     row t('.nombre_essais_validation'),
         &:nombre_essais_validation

--- a/app/views/admin/evaluations/_informations_generales_sidebar.html.arb
+++ b/app/views/admin/evaluations/_informations_generales_sidebar.html.arb
@@ -4,6 +4,15 @@ attributes_table_for resource do
   row :utilisateur
   row :situation
   row :date
+  row(t('admin.evaluations.evaluation.etat')) do |evaluation|
+    if evaluation.termine?
+      status_tag t('admin.evaluations.evaluation.termine'), class: 'green'
+    elsif evaluation.abandon?
+      status_tag t('admin.evaluations.evaluation.abandon'), class: 'red'
+    else
+      status_tag t('admin.evaluations.evaluation.en_cours')
+    end
+  end
   row(t('admin.evaluations.evaluation.temps')) do |evaluation|
     distance_of_time_in_words(evaluation.temps_total)
   end

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -231,6 +231,7 @@ fr:
         reussite: Réussite
         abandon: Abandon
         echec: Échec
+        termine: Terminé
       evaluation_inventaire:
         ouverture_contenant: Ouvertures de contenant
         essai: Essai %{count}

--- a/spec/models/evaluation_base_spec.rb
+++ b/spec/models/evaluation_base_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe EvaluationBase do
+  let(:evaluation) { described_class.new(evenements) }
+
+  context 'lorsque le dernier événement est stop' do
+    let(:evenements) do
+      [
+        build(:evenement_piece_bien_placee),
+        build(:evenement_piece_mal_placee),
+        build(:evenement_stop)
+      ]
+    end
+
+    it { expect(evaluation.abandon?).to be(true) }
+  end
+end

--- a/spec/models/evaluation_base_spec.rb
+++ b/spec/models/evaluation_base_spec.rb
@@ -16,4 +16,10 @@ describe EvaluationBase do
 
     it { expect(evaluation.abandon?).to be(true) }
   end
+
+  it 'envoie une exception not implemented pour la méthode termine?' do
+    expect do
+      described_class.new([]).termine?
+    end.to raise_error(NotImplementedError)
+  end
 end

--- a/spec/models/evaluation_controle_spec.rb
+++ b/spec/models/evaluation_controle_spec.rb
@@ -5,6 +5,30 @@ require 'rails_helper'
 describe EvaluationControle do
   let(:evaluation) { described_class.new(evenements) }
 
+  context 'avec toutes les pieces enregistrées' do
+    let(:evenements) do
+      [
+        build(:evenement_demarrage),
+        *Array.new(60) do
+          build(:evenement_piece_bien_placee)
+        end
+      ]
+    end
+    it { expect(evaluation).to be_termine }
+  end
+
+  context 'avec pas toutes les pieces enregistrées' do
+    let(:evenements) do
+      [
+        build(:evenement_demarrage),
+        *Array.new(4) do
+          build(:evenement_piece_bien_placee)
+        end
+      ]
+    end
+    it { expect(evaluation).to_not be_termine }
+  end
+
   context 'compter les pièces bien placées' do
     let(:evenements) do
       [

--- a/spec/models/evaluation_controle_spec.rb
+++ b/spec/models/evaluation_controle_spec.rb
@@ -36,4 +36,23 @@ describe EvaluationControle do
 
     it { expect(evaluation.nombre_ratees).to eq(1) }
   end
+
+  context 'filtrer les événements pièces' do
+    let(:evenements_pieces) do
+      [
+        build(:evenement_piece_bien_placee),
+        build(:evenement_piece_mal_placee),
+        build(:evenement_piece_ratee)
+      ]
+    end
+
+    let(:evenements) do
+      [
+        build(:evenement_demarrage),
+        *evenements_pieces
+      ]
+    end
+
+    it { expect(evaluation.evenements_pieces).to eq(evenements_pieces) }
+  end
 end

--- a/spec/models/evaluation_inventaire_spec.rb
+++ b/spec/models/evaluation_inventaire_spec.rb
@@ -29,6 +29,7 @@ describe EvaluationInventaire do
     ]
     evaluation = described_class.new(evenements)
     expect(evaluation).to be_reussite
+    expect(evaluation).to be_termine
     expect(evaluation).to_not be_abandon
     expect(evaluation).to_not be_en_cours
   end


### PR DESCRIPTION
J'ai déplacé la méthode `abandon?` dans `EvaluationBase` et implémenté la méthode `termine?` dans la `EvaluationControle`.

Ce qui permet d'afficher dans la sidebar lors de la restitution l'état de l'évaluation.

Ci joint, des capture d'écrans qui montre le résultat.

![Screenshot_2019-04-30 5e53371c-f09d-4067-a8c4-26e060a9ed35 Compétences Pro Serveur](https://user-images.githubusercontent.com/86659/56980772-86e8d280-6b7d-11e9-9d66-36eb51ec3cb6.png)
![Screenshot_2019-04-30 60b81e4b-3d51-4b3f-94d0-5f40edc3d4ad Compétences Pro Serveur](https://user-images.githubusercontent.com/86659/56980773-87816900-6b7d-11e9-994d-131b8f150546.png)
![Screenshot_2019-04-30 f393c3b3-8691-4dc9-b6c4-9d53f778c705 Compétences Pro Serveur](https://user-images.githubusercontent.com/86659/56980778-89e3c300-6b7d-11e9-98ec-1113cd6627fc.png)
