### PR TITLE
Inventaire: affiche le nombre d'erreurs par essai

### DIFF
--- a/app/models/evaluation_inventaire.rb
+++ b/app/models/evaluation_inventaire.rb
@@ -16,6 +16,15 @@ class EvaluationInventaire < EvaluationBase
     def temps_total
       @evenements.last.date - @date_depart_situation
     end
+
+    def nombre_erreurs
+      return nil unless @evenements.last.nom == EVENEMENT[:SAISIE_INVENTAIRE]
+
+      @evenements.last.donnees['reponses'].inject(0) do |nombre_erreurs, (_id, reponse)|
+        nombre_erreurs += 1 unless reponse['reussite']
+        nombre_erreurs
+      end
+    end
   end
 
   def reussite?

--- a/app/views/admin/evaluations/_evaluation_inventaire.html.arb
+++ b/app/views/admin/evaluations/_evaluation_inventaire.html.arb
@@ -36,5 +36,6 @@ panel t('.restitution_essais') do
       "+#{distance_of_time_in_words(essai.temps_total)}"
     end
     column t('.ouverture_contenant'), &:nombre_ouverture_contenant
+    column t('.nombre_erreurs'), &:nombre_erreurs
   end
 end

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -235,6 +235,7 @@ fr:
         ouverture_contenant: Ouvertures de contenant
         essai: Essai %{count}
         nombre_essais_validation: "Nombre d'essais"
+        nombre_erreurs: "Nombre d'erreurs"
         restitution_essais: Détail des essais
         informations_specifiques: Informations spécifiques
       evaluation_controle:

--- a/spec/factories/evenement.rb
+++ b/spec/factories/evenement.rb
@@ -17,13 +17,13 @@ FactoryBot.define do
 
       trait :ok do
         donnees do
-          { reussite: true }
+          { reussite: true, reponses: {} }
         end
       end
 
       trait :echec do
         donnees do
-          { reussite: false }
+          { reussite: false, reponses: {} }
         end
       end
     end

--- a/spec/features/evaluation_spec.rb
+++ b/spec/features/evaluation_spec.rb
@@ -17,7 +17,7 @@ describe 'Admin - Evaluation', type: :feature do
   end
 
   scenario 'rapport de la situation inventaire' do
-    create :evenement_saisie_inventaire, situation: 'inventaire', session_id: 'session_inventaire'
+    create :evenement_saisie_inventaire, :echec, session_id: 'session_inventaire'
     visit admin_evaluation_path('session_inventaire')
     expect(page).to have_content('Échec')
   end

--- a/spec/models/evaluation_inventaire_spec.rb
+++ b/spec/models/evaluation_inventaire_spec.rb
@@ -12,6 +12,46 @@ describe EvaluationInventaire do
       evaluation = described_class.new(evenements, 5.minute.ago)
       expect(evaluation.temps_total).to be_within(0.1).of(240)
     end
+
+    describe '#nombre_erreurs' do
+      it 'est à 0 en cas de réussite' do
+        evenements = [
+          build(:evenement_saisie_inventaire, :ok, donnees: {
+                  reussite: true,
+                  reponses: {
+                    '1': { quantite: 2, reussite: true },
+                    '2': { quantite: 1, reussite: true },
+                    '3': { quantite: 4, reussite: true }
+                  }
+                })
+        ]
+        evaluation = described_class.new(evenements, 5.minute.ago)
+        expect(evaluation.nombre_erreurs).to eql(0)
+      end
+
+      it 'est à 2' do
+        evenements = [
+          build(:evenement_saisie_inventaire, :echec, donnees: {
+                  reussite: false,
+                  reponses: {
+                    '1': { quantite: 2, reussite: true },
+                    '2': { quantite: 1, reussite: false },
+                    '3': { quantite: 4, reussite: false }
+                  }
+                })
+        ]
+        evaluation = described_class.new(evenements, 5.minute.ago)
+        expect(evaluation.nombre_erreurs).to eql(2)
+      end
+
+      it "est à nil lorsque le dernier événement n'est pas une saisie d'inventaire" do
+        evenements = [
+          build(:evenement_ouverture_contenant)
+        ]
+        evaluation = described_class.new(evenements, 5.minute.ago)
+        expect(evaluation.nombre_erreurs).to be_nil
+      end
+    end
   end
 
   it 'session_id retourne le session_id' do


### PR DESCRIPTION
Pour faciliter la restitution, le nombre d'erreurs lors de la saisie d'inventaire est affiché par essai.

![Screenshot_2019-05-02 184e31a0-c7c6-44a6-92ed-6b60c6a7fa4c Compétences Pro Serveur](https://user-images.githubusercontent.com/86659/57093612-a400db00-6d0e-11e9-974d-fd9a8393d67d.png)
