### PR TITLE
[NETTOYAGE] fix un test qui était dépendant de l'état de la base de données

### DIFF
--- a/spec/requests/evenements_spec.rb
+++ b/spec/requests/evenements_spec.rb
@@ -28,14 +28,15 @@ describe 'Evenement API', type: :request do
     end
 
     context 'Quand une requête est valide' do
-      before { post '/api/evenements', params: payload_valide }
 
       it 'Crée un événement' do
-        expect(Evenement.count).to eq 1
+        expect{ post '/api/evenements', params: payload_valide }
+          .to change{Evenement.count}.by(1)
         expect(Evenement.last.date).to eq DateTime.new(2019, 0o2, 25, 16, 11, 29)
       end
 
       it 'retourne une 201' do
+        post '/api/evenements', params: payload_valide
         expect(response).to have_http_status(201)
       end
     end


### PR DESCRIPTION
En voulant lancer les tests serveur sur mon ordinateur, je suis tombé sur ce test qui ne passait pas car j'ai déjà des événements en base avant le démarrage du test. 

J'ai changé le expected pour vérifier l'incrément du nombre d'événement plutôt que juste le nombre.
