### PR TITLE
Affiche l'évaluation des compétences pour toutes les situations

### DIFF
--- a/app/admin/evaluations.rb
+++ b/app/admin/evaluations.rb
@@ -45,6 +45,7 @@ ActiveAdmin.register Evenement, as: 'Evaluations' do
 
   show title: :session_id do
     render chemin_vue, evaluation: resource
+    render 'evaluation_competences', evaluation: resource
   end
 
   sidebar :informations_generales, only: :show

--- a/app/models/evaluation/base.rb
+++ b/app/models/evaluation/base.rb
@@ -32,5 +32,9 @@ module Evaluation
     def termine?
       raise NotImplementedError
     end
+
+    def competences
+      {}
+    end
   end
 end

--- a/app/views/admin/evaluations/_evaluation_competences.html.arb
+++ b/app/views/admin/evaluations/_evaluation_competences.html.arb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+panel t('.titre') do
+  attributes_table_for evaluation do
+    evaluation.competences.each do |competence, niveau|
+      row(t(".#{competence}")) { niveau }
+    end
+  end
+end

--- a/app/views/admin/evaluations/_evaluation_controle.html.arb
+++ b/app/views/admin/evaluations/_evaluation_controle.html.arb
@@ -6,8 +6,5 @@ panel t('.restitution_controle') do
     row t('.pieces_mal_placees'), &:nombre_mal_placees
     row t('.pieces_ratees'), &:nombre_ratees
     row(t('.frise')) { render 'controle_frise_pieces', evaluation: evaluation }
-    evaluation.competences.each do |competence, niveau|
-      row(t(".#{competence}")) { niveau }
-    end
   end
 end

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -245,6 +245,8 @@ fr:
         pieces_bien_placees: Pièces bien placées
         pieces_mal_placees: Pièces mal placées
         pieces_ratees: Pièces ratées
-        rapidite: Rapidité de traitement
-        comparaison_tri: Comparaison et tri
+      evaluation_competences:
         attention_concentration: Attention/Concentration
+        comparaison_tri: Comparaison et tri
+        rapidite: Rapidité de traitement
+        titre: Évaluation des compétences

--- a/spec/models/evaluation/base_spec.rb
+++ b/spec/models/evaluation/base_spec.rb
@@ -22,4 +22,8 @@ describe Evaluation::Base do
       described_class.new([]).termine?
     end.to raise_error(NotImplementedError)
   end
+
+  it 'renvoie par défaut une liste vide pour les compétences évaluées' do
+    expect(described_class.new([]).competences).to eql({})
+  end
 end


### PR DESCRIPTION
J'ai uniformisé la gestion de l'affichage des compétences dans les situations. Un template est rendu systématiquement et itère sur les compétences pour afficher le résultat. Cela n'affiche rien pour le moment dans l'inventaire, mais cela arrive très bientôt !

Pour l'inventaire:
![Screenshot_2019-05-06 9f48aff7-b333-4c27-b80c-9068dfa6c879 Compétences Pro Serveur](https://user-images.githubusercontent.com/86659/57222908-9eeca600-7004-11e9-862a-a48ea3487206.png)
Pour le contrôle
![Screenshot_2019-05-06 2298ddde-322a-4788-b487-0f348ee620fa Compétences Pro Serveur](https://user-images.githubusercontent.com/86659/57222909-9eeca600-7004-11e9-91ef-a81dbea3e923.png)
