### PR TITLE
Inventaire: évaluation de la compétence Organisation et méthode

### DIFF
--- a/app/models/competence.rb
+++ b/app/models/competence.rb
@@ -10,4 +10,5 @@ module Competence
   RAPIDITE = :rapidite
   COMPARAISON_TRI = :comparaison_tri
   ATTENTION_CONCENTRATION = :attention_concentration
+  ORGANISATION_METHODE = :organisation_methode
 end

--- a/app/models/evaluation/inventaire.rb
+++ b/app/models/evaluation/inventaire.rb
@@ -54,5 +54,13 @@ module Evaluation
         Essai.new(evenements, date_depart)
       end
     end
+
+    def competences
+      {
+        ::Competence::ORGANISATION_METHODE => Inventaire::OrganisationMethode
+      }.each_with_object({}) do |(competence, classe), resultat|
+        resultat[competence] = classe.new(self).niveau
+      end
+    end
   end
 end

--- a/app/models/evaluation/inventaire/organisation_methode.rb
+++ b/app/models/evaluation/inventaire/organisation_methode.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Evaluation
+  class Inventaire
+    class OrganisationMethode < Evaluation::Competence::Base
+      def niveau
+        return ::Competence::NIVEAU_INDETERMINE unless @evaluation.reussite?
+
+        nombre_ouverture_contenant = @evaluation.nombre_ouverture_contenant
+        case nombre_ouverture_contenant
+        when 0..70 then ::Competence::NIVEAU_4
+        when 70..120 then ::Competence::NIVEAU_3
+        when 120..250 then ::Competence::NIVEAU_2
+        else ::Competence::NIVEAU_1
+        end
+      end
+    end
+  end
+end

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -250,3 +250,4 @@ fr:
         comparaison_tri: Comparaison et tri
         rapidite: Rapidité de traitement
         titre: Évaluation des compétences
+        organisation_methode: Organisation et méthode

--- a/spec/models/evaluation/inventaire/organisation_methode_spec.rb
+++ b/spec/models/evaluation/inventaire/organisation_methode_spec.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Evaluation::Inventaire::OrganisationMethode do
+  let(:evaluation) { double }
+
+  context 'en réussite et moins de 70 ouvertures de contenants' do
+    it 'a le niveau 4' do
+      expect(evaluation).to receive(:reussite?).and_return(true)
+      expect(evaluation).to receive(:nombre_ouverture_contenant).and_return(60)
+      expect(
+        described_class.new(evaluation).niveau
+      ).to eql(Competence::NIVEAU_4)
+    end
+  end
+
+  context 'en réussite et entre de 70 et 120 ouvertures de contenants' do
+    it 'a le niveau 3' do
+      expect(evaluation).to receive(:reussite?).and_return(true)
+      expect(evaluation).to receive(:nombre_ouverture_contenant).and_return(80)
+      expect(
+        described_class.new(evaluation).niveau
+      ).to eql(Competence::NIVEAU_3)
+    end
+  end
+
+  context 'en réussite et entre de 120 et 250 ouvertures de contenants' do
+    it 'a le niveau 2' do
+      expect(evaluation).to receive(:reussite?).and_return(true)
+      expect(evaluation).to receive(:nombre_ouverture_contenant).and_return(200)
+      expect(
+        described_class.new(evaluation).niveau
+      ).to eql(Competence::NIVEAU_2)
+    end
+  end
+
+  context 'en réussite et plus de 250 ouvertures de contenants' do
+    it 'a le niveau 2' do
+      expect(evaluation).to receive(:reussite?).and_return(true)
+      expect(evaluation).to receive(:nombre_ouverture_contenant).and_return(300)
+      expect(
+        described_class.new(evaluation).niveau
+      ).to eql(Competence::NIVEAU_1)
+    end
+  end
+
+  context 'en cas de non reussite' do
+    it 'a le niveau indetermine' do
+      expect(evaluation).to receive(:reussite?).and_return(false)
+      expect(
+        described_class.new(evaluation).niveau
+      ).to eql(Competence::NIVEAU_INDETERMINE)
+    end
+  end
+end

--- a/spec/models/evaluation/inventaire_spec.rb
+++ b/spec/models/evaluation/inventaire_spec.rb
@@ -158,4 +158,14 @@ describe Evaluation::Inventaire do
       expect(essai.temps_total).to within(0.1).of(300)
     end
   end
+
+  describe '#competences' do
+    it 'retourne les compétences évaluées' do
+      evenements = [
+        build(:evenement_demarrage)
+      ]
+      evaluation = described_class.new(evenements)
+      expect(evaluation.competences.keys).to match_array([Competence::ORGANISATION_METHODE])
+    end
+  end
 end


### PR DESCRIPTION
J'ai rajouté l'évaluation de la compétence "Organisation et méthode" pour la situation inventaire.

Les règles sont défini dans le fichier https://docs.google.com/spreadsheets/d/1c_dkbHy2S3WRqx_WcquvsnAcI4L4QlU6b-tDnnT3XP4/edit#gid=0

La compétence est affiché comme il se doit dans la page de l'évaluation

![Screenshot_2019-05-06 fcb057bb-7f54-4829-a57a-b7099db2c335 Compétences Pro Serveur](https://user-images.githubusercontent.com/86659/57231187-54762400-701a-11e9-977c-53a5a0eb1d1f.png)

Contribue à #45 
