### PR TITLE
 Corrige Controle#shift pour toujours avoir un tableau. 

### DIFF
--- a/app/models/evaluation/controle.rb
+++ b/app/models/evaluation/controle.rb
@@ -32,7 +32,7 @@ module Evaluation
       @evenements.find_all { |e| noms_evenements_pieces.include?(e.nom) }
     end
 
-    def shift(nombre)
+    def enleve_premiers_evenements_pieces(nombre)
       self.class.new(evenements_pieces[nombre..-1] || [])
     end
 

--- a/app/models/evaluation/controle.rb
+++ b/app/models/evaluation/controle.rb
@@ -26,14 +26,20 @@ module Evaluation
       compte_nom_evenements EVENEMENT[:PIECE_RATEE]
     end
 
+    def noms_evenements_pieces
+      EVENEMENT.slice(:PIECE_BIEN_PLACEE, :PIECE_MAL_PLACEE, :PIECE_RATEE).values
+    end
+
     def evenements_pieces
-      noms_evenements_pieces =
-        EVENEMENT.slice(:PIECE_BIEN_PLACEE, :PIECE_MAL_PLACEE, :PIECE_RATEE).values
       @evenements.find_all { |e| noms_evenements_pieces.include?(e.nom) }
     end
 
     def enleve_premiers_evenements_pieces(nombre)
-      self.class.new(evenements_pieces[nombre..-1] || [])
+      compteur = 0
+      nouveaux_evenements = evenements.reject do |evenement|
+        noms_evenements_pieces.include?(evenement.nom) && (compteur += 1) <= nombre
+      end
+      self.class.new(nouveaux_evenements)
     end
 
     def competences

--- a/app/models/evaluation/controle.rb
+++ b/app/models/evaluation/controle.rb
@@ -33,7 +33,7 @@ module Evaluation
     end
 
     def shift(nombre)
-      self.class.new(evenements_pieces[nombre..-1])
+      self.class.new(evenements_pieces[nombre..-1] || [])
     end
 
     def competences

--- a/app/models/evaluation/controle/comparaison_tri.rb
+++ b/app/models/evaluation/controle/comparaison_tri.rb
@@ -5,7 +5,7 @@ module Evaluation
     class ComparaisonTri < Evaluation::Competence::Base
       def initialize(evaluation_controle)
         super(evaluation_controle)
-        @evaluation_hors_4_premiers = evaluation_controle.shift(4)
+        @evaluation_hors_4_premiers = evaluation_controle.enleve_premiers_evenements_pieces(4)
       end
 
       def niveau

--- a/spec/models/evaluation/controle/comparaison_tri_spec.rb
+++ b/spec/models/evaluation/controle/comparaison_tri_spec.rb
@@ -8,7 +8,8 @@ describe Evaluation::Controle::ComparaisonTri do
 
   before(:each) do
     allow(evaluation).to receive(:evenements).and_return([1, 2, 3, 4])
-    allow(evaluation).to receive(:shift).with(4).and_return(evaluation_hors_4_premiers)
+    allow(evaluation).to receive(:enleve_premiers_evenements_pieces)
+      .with(4).and_return(evaluation_hors_4_premiers)
   end
 
   context "lorsqu'il n'y a pas d'erreurs ou de ratées" do

--- a/spec/models/evaluation/controle_spec.rb
+++ b/spec/models/evaluation/controle_spec.rb
@@ -81,7 +81,7 @@ describe Evaluation::Controle do
     it { expect(evaluation.evenements_pieces).to eq(evenements_pieces) }
   end
 
-  describe '#shift' do
+  describe '#enleve_premiers_evenements_pieces' do
     let(:evenements) do
       [
         build(:evenement_demarrage),
@@ -92,15 +92,15 @@ describe Evaluation::Controle do
     end
 
     it 'retourne une instance EvaluationControle' do
-      expect(evaluation.shift(2)).to be_a(described_class)
+      expect(evaluation.enleve_premiers_evenements_pieces(2)).to be_a(described_class)
     end
 
     it 'evenements est toujours un tableau vide' do
-      expect(evaluation.shift(4).evenements).to eql([])
+      expect(evaluation.enleve_premiers_evenements_pieces(4).evenements).to eql([])
     end
 
     it 'enlève les x premiers événements de pièces' do
-      evaluation.shift(2).evenements.tap do |evenements|
+      evaluation.enleve_premiers_evenements_pieces(2).evenements.tap do |evenements|
         expect(evenements.count).to eql(1)
         expect(evenements.first.nom).to eql(build(:evenement_piece_bien_placee).nom)
       end

--- a/spec/models/evaluation/controle_spec.rb
+++ b/spec/models/evaluation/controle_spec.rb
@@ -82,12 +82,14 @@ describe Evaluation::Controle do
   end
 
   describe '#enleve_premiers_evenements_pieces' do
+    let(:demarrage) { build(:evenement_demarrage) }
+    let(:bien_placee) { build(:evenement_piece_bien_placee) }
     let(:evenements) do
       [
-        build(:evenement_demarrage),
+        demarrage,
         build(:evenement_piece_ratee),
         build(:evenement_piece_mal_placee),
-        build(:evenement_piece_bien_placee)
+        bien_placee
       ]
     end
 
@@ -95,14 +97,13 @@ describe Evaluation::Controle do
       expect(evaluation.enleve_premiers_evenements_pieces(2)).to be_a(described_class)
     end
 
-    it 'evenements est toujours un tableau vide' do
-      expect(evaluation.enleve_premiers_evenements_pieces(4).evenements).to eql([])
+    it 'enlève tout les événements de pièces' do
+      expect(evaluation.enleve_premiers_evenements_pieces(4).evenements).to eql([demarrage])
     end
 
     it 'enlève les x premiers événements de pièces' do
       evaluation.enleve_premiers_evenements_pieces(2).evenements.tap do |evenements|
-        expect(evenements.count).to eql(1)
-        expect(evenements.first.nom).to eql(build(:evenement_piece_bien_placee).nom)
+        expect(evenements).to eql([demarrage, bien_placee])
       end
     end
   end

--- a/spec/models/evaluation/controle_spec.rb
+++ b/spec/models/evaluation/controle_spec.rb
@@ -95,6 +95,10 @@ describe Evaluation::Controle do
       expect(evaluation.shift(2)).to be_a(described_class)
     end
 
+    it 'evenements est toujours un tableau vide' do
+      expect(evaluation.shift(4).evenements).to eql([])
+    end
+
     it 'enlève les x premiers événements de pièces' do
       evaluation.shift(2).evenements.tap do |evenements|
         expect(evenements.count).to eql(1)


### PR DESCRIPTION
On a bug actuellement dans la situation contrôle lorsque l'on regarde l'évaluation et qu'il y a eu moins de 4 pièces. Le rendu crash. 

```
undefined method `count' for nil:NilClass
app/models/evaluation/base.rb:17:in `compte_nom_evenements'
app/models/evaluation/controle.rb:22:in `nombre_mal_placees'
app/models/evaluation/controle/comparaison_tri.rb:14:in `niveau'
app/models/evaluation/controle.rb:45:in `block in competences'
app/models/evaluation/controle.rb:44:in `each'
app/models/evaluation/controle.rb:44:in `each_with_object'
app/models/evaluation/controle.rb:44:in `competences'
app/views/admin/evaluations/_evaluation_competences.html.arb:6:in `block (3 levels) in _app_views_admin_evaluations__evaluation_competences_html_arb__710404898700250126_70006424148440'
app/views/admin/evaluations/_evaluation_competences.html.arb:5:in `block (2 levels) in _app_views_admin_evaluations__evaluation_competences_html_arb__710404898700250126_70006424148440'
app/views/admin/evaluations/_evaluation_competences.html.arb:4:in `block in _app_views_admin_evaluations__evaluation_competences_html_arb__710404898700250126_70006424148440'
app/views/admin/evaluations/_evaluation_competences.html.arb:1:in `new'
app/views/admin/evaluations/_evaluation_competences.html.arb:1:in `_app_views_admin_evaluations__evaluation_competences_html_arb__710404898700250126_70006424148440'
app/admin/evaluations.rb:48:in `block (2 levels) in <main>'
```

J'ai fait en sorte que la méthode `shift` ait toujours un tableau d'événements, même vide.