### PR TITLE
Utilise ruby 2.6 sur circle ci et avec rubocop

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   build:
     parallelism: 1
     docker:
-      - image: circleci/ruby:2.5.3-node
+      - image: circleci/ruby:2.6.1-node
         environment:
           BUNDLE_JOBS: 3
           BUNDLE_RETRY: 3

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,7 @@
 Documentation:
   Enabled: false
 AllCops:
+  TargetRubyVersion: 2.6
   Exclude:
     - 'bin/**/*'
     - 'db/**/*'

--- a/app/models/evaluation/controle/comprehension_consigne.rb
+++ b/app/models/evaluation/controle/comprehension_consigne.rb
@@ -14,8 +14,8 @@ module Evaluation
       end
 
       def abandon_en_moins_de_11_pieces_avec_erreurs?
-        @evaluation.abandon? && nombre_pieces < 11 && @evaluation.nombre_loupees > 0 &&
-          @evaluation.nombre_rejoue_consigne > 0
+        @evaluation.abandon? && nombre_pieces < 11 && @evaluation.nombre_loupees.positive? &&
+          @evaluation.nombre_rejoue_consigne.positive?
       end
 
       def nombre_pieces


### PR DESCRIPTION
On n'était pas très cohérent entre circle ci qui utilisé ruby 2.5 et rubocop qui analyse par défaut en mode ruby 2.2. C'est d'aplomb désormais.