### PR TITLE
Tri: affichage d'informations basique de restitution

### DIFF
--- a/app/models/evaluation/tri.rb
+++ b/app/models/evaluation/tri.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module Evaluation
+  class Tri < Base
+    PIECES_TOTAL = 48
+
+    EVENEMENT = {
+      PIECE_BIEN_PLACEE: 'pieceBienPlacee',
+      PIECE_MAL_PLACEE: 'pieceMalPlacee'
+    }.freeze
+
+    def termine?
+      nombre_bien_placees == PIECES_TOTAL
+    end
+
+    def nombre_bien_placees
+      compte_nom_evenements EVENEMENT[:PIECE_BIEN_PLACEE]
+    end
+
+    def nombre_mal_placees
+      compte_nom_evenements EVENEMENT[:PIECE_MAL_PLACEE]
+    end
+  end
+end

--- a/app/models/fabrique_evaluation.rb
+++ b/app/models/fabrique_evaluation.rb
@@ -5,7 +5,8 @@ class FabriqueEvaluation
     def instancie(situation, evenements)
       classe_evaluation = {
         'inventaire' => Evaluation::Inventaire,
-        'controle' => Evaluation::Controle
+        'controle' => Evaluation::Controle,
+        'tri' => Evaluation::Tri
       }
 
       classe_evaluation[situation].new(evenements)

--- a/app/views/admin/evaluations/_evaluation_tri.html.arb
+++ b/app/views/admin/evaluations/_evaluation_tri.html.arb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+panel t('.restitution_tri') do
+  attributes_table_for evaluation do
+    row t('.pieces_bien_placees'), &:nombre_bien_placees
+    row t('.pieces_mal_placees'), &:nombre_mal_placees
+  end
+end

--- a/config/locales/views/evaluations.yml
+++ b/config/locales/views/evaluations.yml
@@ -66,6 +66,10 @@ fr:
         pieces_bien_placees: Pièces bien placées
         pieces_mal_placees: Pièces mal placées
         pieces_non_triees: Pièces non triées
+      evaluation_tri:
+        restitution_tri: Restitution de la situation tri
+        pieces_bien_placees: Pièces bien placées
+        pieces_mal_placees: Pièces mal placées
       evaluation_competences:
         attention_concentration: Attention/Concentration
         comparaison_tri: Comparaison et tri

--- a/spec/models/evaluation/tri_spec.rb
+++ b/spec/models/evaluation/tri_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Evaluation::Tri do
+  let(:evaluation) { described_class.new(evenements) }
+
+  context 'avec toutes les pieces enregistrées' do
+    let(:evenements) do
+      [
+        build(:evenement_demarrage),
+        build(:evenement_piece_mal_placee),
+        *Array.new(Evaluation::Tri::PIECES_TOTAL) do
+          build(:evenement_piece_bien_placee)
+        end
+      ]
+    end
+    it { expect(evaluation).to be_termine }
+  end
+
+  context 'avec pas toutes les pieces enregistrées' do
+    let(:evenements) do
+      [
+        build(:evenement_demarrage),
+        *Array.new(4) do
+          build(:evenement_piece_bien_placee)
+        end
+      ]
+    end
+    it { expect(evaluation).to_not be_termine }
+  end
+
+  context 'compter les pièces bien placées' do
+    let(:evenements) do
+      [
+        build(:evenement_piece_bien_placee),
+        build(:evenement_piece_mal_placee)
+      ]
+    end
+
+    it { expect(evaluation.nombre_bien_placees).to eq(1) }
+  end
+
+  context 'compter les pièces mal placées' do
+    let(:evenements) do
+      [
+        build(:evenement_piece_mal_placee),
+        build(:evenement_piece_mal_placee)
+      ]
+    end
+
+    it { expect(evaluation.nombre_mal_placees).to eq(2) }
+  end
+end


### PR DESCRIPTION
Pour permettre une restitution minimale de la situation tri, j'ai rajouté la classe d'évaluation qui compte les quelques événements possible (voir betagouv/competences-pro#299) et indique si c'est terminé ou non.

![Screenshot_2019-05-27 cd2cfd0c-b350-4dce-8746-92f5ce1fc848 Compétences Pro Serveur](https://user-images.githubusercontent.com/86659/58423202-cd562200-8094-11e9-96ea-5fd2db79ee8b.png)
