### PR TITLE
affiche le tri dans le rapport global

### DIFF
--- a/app/assets/stylesheets/evaluation_globale.scss
+++ b/app/assets/stylesheets/evaluation_globale.scss
@@ -1,6 +1,7 @@
 $couleur-separateur: #afc5d0;
 $couleur-inventaire: #39c4d4;
 $couleur-controle: #e3b055;
+$couleur-tri: #9b7cd1;
 $couleur-fond-principale: #d8e8f7;
 $couleur-texte: #001c36;
 
@@ -120,4 +121,7 @@ $border-radius: .75rem;
     @include applique-theme($couleur-controle);
   }
 
+  .tri {
+    @include applique-theme($couleur-tri);
+  }
 }

--- a/app/models/evaluation/tri.rb
+++ b/app/models/evaluation/tri.rb
@@ -20,5 +20,9 @@ module Evaluation
     def nombre_mal_placees
       compte_nom_evenements EVENEMENT[:PIECE_MAL_PLACEE]
     end
+
+    def nombre_non_triees
+      PIECES_TOTAL - nombre_bien_placees
+    end
   end
 end

--- a/app/views/admin/evaluation_globale/_tri.html.arb
+++ b/app/views/admin/evaluation_globale/_tri.html.arb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
-div class: 'row inventaire' do
+div class: 'row tri' do
   render 'badge', label: t('.efficience'), valeur: en_pourcentage(evaluation.efficience)
   render 'badge', label: t('.duree'), valeur: distance_of_time_in_words(evaluation.temps_total)
-  render 'badge', label: t('.nombre_essais'), valeur: evaluation.nombre_essais_validation
+  render 'badge', label: t('.nombre_erreurs'), valeur: evaluation.nombre_mal_placees
+  render 'badge', label: t('.reste_plateau'), valeur: evaluation.nombre_non_triees
 end

--- a/config/locales/views/evaluations.yml
+++ b/config/locales/views/evaluations.yml
@@ -3,19 +3,23 @@ fr:
     evaluation_globale:
       commun: &commun
         efficience: Efficience
+        nombre_erreurs: "Nombre d'erreurs"
+        duree: Durée de passation
       controle:
         <<: *commun
         nombre_trop_tard: 'Nombre de trop tard'
-        nombre_erreurs: "Nombre d'erreurs"
         arret_au: "Arrêt au .. / 60"
       inventaire:
         <<: *commun
-        duree: Durée de passation
         nombre_essais: Nbre d'essais
+      tri:
+        <<: *commun
+        reste_plateau: Reste plateau
       evaluation_globale:
         situation: 'Situation %{situation}'
         inventaire: Stock
         controle: Contrôle
+        tri: Tri
         efficience_globale: "Efficience globale : %{efficience}"
       evaluation_competence:
         indetermine: non obs.

--- a/spec/models/evaluation/tri_spec.rb
+++ b/spec/models/evaluation/tri_spec.rb
@@ -28,6 +28,7 @@ describe Evaluation::Tri do
       ]
     end
     it { expect(evaluation).to_not be_termine }
+    it { expect(evaluation.nombre_non_triees).to eq(Evaluation::Tri::PIECES_TOTAL - 4) }
   end
 
   context 'compter les pièces bien placées' do


### PR DESCRIPTION
Intègre la section Tri dans le rapport global.

Il restera à intégrer les textes des compétences quand elles seront évaluées.
Version Web :
![Capture d’écran 2019-05-29 à 14 30 33](https://user-images.githubusercontent.com/28393/58557318-6c5a5580-821e-11e9-89d1-f57ad01e59e3.png)


Exemple de rapport généré
[evaluation_avec_tri.pdf](https://github.com/betagouv/competences-pro-serveur/files/3232415/evaluation_avec_tri.pdf)

Contribue à #63 