### PR TITLE
Suppression des événements d'une évaluation

### DIFF
--- a/app/admin/evaluations.rb
+++ b/app/admin/evaluations.rb
@@ -4,8 +4,16 @@ ActiveAdmin.register Evenement, as: 'Evaluations' do
   config.sort_order = 'date_desc'
   actions :index, :show
 
-  batch_action :evaluation_globale_pour do |ids|
+  batch_action :evaluation_globale_pour, priority: 1 do |ids|
     redirect_to admin_evaluation_globale_path(evaluation_ids: ids)
+  end
+
+  batch_action :destroy, confirm: I18n.t('active_admin.evaluations.confirme_suppression') do |ids|
+    ids.each do |id|
+      FabriqueEvaluation.depuis_evenement_id(id).supprimer
+    end
+    redirect_to collection_path,
+                alert: I18n.t('active_admin.evaluations.supprimees', count: ids.size)
   end
 
   controller do

--- a/app/models/evaluation/base.rb
+++ b/app/models/evaluation/base.rb
@@ -21,6 +21,10 @@ module Evaluation
       @evenements = evenements
     end
 
+    def supprimer
+      Evenement.where(id: evenements.pluck(:id)).delete_all
+    end
+
     def compte_nom_evenements(nom)
       evenements.count { |e| e.nom == nom }
     end

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -223,3 +223,8 @@ fr:
       index:
         rapport: Rapport
         evenements: Évenements
+    evaluations:
+      confirme_suppression: Voulez vous vraiment supprimer ces évaluations ?
+      supprimees:
+        one: Évaluation supprimée
+        other: Évaluations supprimées

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -228,3 +228,6 @@ fr:
       supprimees:
         one: Évaluation supprimée
         other: Évaluations supprimées
+    batch_actions:
+      labels:
+        evaluation_globale_pour: Évaluation globale pour

--- a/spec/models/evaluation/base_spec.rb
+++ b/spec/models/evaluation/base_spec.rb
@@ -64,4 +64,23 @@ describe Evaluation::Base do
       expect(evaluation.efficience).to be_nil
     end
   end
+
+  describe '#supprimer' do
+    let(:evenements) do
+      [
+        create(:evenement_demarrage),
+        create(:evenement_stop)
+      ]
+    end
+
+    let(:where) { double }
+
+    it "supprime les événements de l'évaluation" do
+      expect(where).to receive(:delete_all)
+      expect(Evenement).to receive(:where)
+        .with(id: [evenements[0].id, evenements[1].id])
+        .and_return(where)
+      evaluation.supprimer
+    end
+  end
 end


### PR DESCRIPTION
Pour permettre le nettoyage des évaluations, j'ai rajouté l'action de masse de suppression. 

![Screenshot_2019-06-04 Evaluations Compétences Pro Serveur](https://user-images.githubusercontent.com/86659/58907918-8a88ef80-870f-11e9-8a7b-7a38cda5dfed.png)
