### PR TITLE
Corrige l'affichage d'un événement en renommant une classe css.

### DIFF
--- a/app/assets/stylesheets/active_admin.scss
+++ b/app/assets/stylesheets/active_admin.scss
@@ -17,7 +17,7 @@
 //   .status_tag { background: #6090DB; }
 
 
-.evenement {
+.evenement-piece {
   display: inline-block;
   width: 10px;
   height: 30px;

--- a/app/views/admin/evaluations/_controle_frise_pieces.html.erb
+++ b/app/views/admin/evaluations/_controle_frise_pieces.html.erb
@@ -1,8 +1,8 @@
 <div>
 <% evaluation.evenements_pieces.each do |evenement_piece| %>
-  <span class="evenement <%= evenement_piece.nom.underscore.dasherize %>"></span>
+  <span class="evenement-piece <%= evenement_piece.nom.underscore.dasherize %>"></span>
 <% end %>
 </div>
-<span class="evenement piece-bien-placee"></span> <%= t('admin.evaluations.evaluation_controle.pieces_bien_placees') %>
-<span class="evenement piece-mal-placee"></span> <%= t('admin.evaluations.evaluation_controle.pieces_mal_placees') %>
-<span class="evenement piece-ratee"></span> <%= t('admin.evaluations.evaluation_controle.pieces_non_triees') %>
+<span class="evenement-piece piece-bien-placee"></span> <%= t('admin.evaluations.evaluation_controle.pieces_bien_placees') %>
+<span class="evenement-piece piece-mal-placee"></span> <%= t('admin.evaluations.evaluation_controle.pieces_mal_placees') %>
+<span class="evenement-piece piece-ratee"></span> <%= t('admin.evaluations.evaluation_controle.pieces_non_triees') %>


### PR DESCRIPTION
Les classes css utilisées pour la frise dans la restitution de la
situation contrôle entrait en conflit avec celles généré par activeadmin
dans la page d'un événement.

Fix #75 