### PR TITLE
Corrige le crash dans le calcul de la persévérance dans le cas d'un abandon

### DIFF
--- a/app/models/evaluation/inventaire.rb
+++ b/app/models/evaluation/inventaire.rb
@@ -48,7 +48,7 @@ module Evaluation
     alias termine? reussite?
 
     def en_cours?
-      evenements.last.nom != EVENEMENT[:SAISIE_INVENTAIRE] && !abandon?
+      !dernier_evenement_est_une_saisie_inventaire? && !abandon?
     end
 
     def nombre_ouverture_contenant
@@ -63,12 +63,16 @@ module Evaluation
       evenements.last.nom == EVENEMENT[:SAISIE_INVENTAIRE]
     end
 
+    def essais_verifies
+      dernier_evenement_est_une_saisie_inventaire? ? essais : essais[0...-1]
+    end
+
     def essais
-      essais = evenements.chunk_while do |evenement_avant, _|
+      evenements_par_essais = evenements.chunk_while do |evenement_avant, _|
         evenement_avant.nom != EVENEMENT[:SAISIE_INVENTAIRE]
       end
       date_depart = evenements.first.date
-      essais.map do |evenements|
+      evenements_par_essais.map do |evenements|
         Essai.new(evenements, date_depart)
       end
     end

--- a/app/models/evaluation/inventaire/comprehension_consigne.rb
+++ b/app/models/evaluation/inventaire/comprehension_consigne.rb
@@ -15,7 +15,8 @@ module Evaluation
       end
 
       def un_essai_avec_8_erreurs
-        @evaluation.nombre_essais_validation == 1 && @evaluation.essais.first.nombre_erreurs == 8
+        @evaluation.nombre_essais_validation == 1 &&
+          @evaluation.essais_verifies.first.nombre_erreurs == 8
       end
     end
   end

--- a/app/models/evaluation/inventaire/perseverance.rb
+++ b/app/models/evaluation/inventaire/perseverance.rb
@@ -27,7 +27,7 @@ module Evaluation
 
       def essai_avec_de_bonnes_reponses_en_moins_22_min
         @evaluation.nombre_essais_validation.positive? &&
-          @evaluation.essais.last.nombre_erreurs < 8 &&
+          @evaluation.essais_verifies.last.nombre_erreurs < 8 &&
           @evaluation.temps_total < 22.minutes.to_i
       end
     end

--- a/app/models/evaluation/inventaire/vigilance_controle.rb
+++ b/app/models/evaluation/inventaire/vigilance_controle.rb
@@ -24,7 +24,8 @@ module Evaluation
       end
 
       def essais_sans_prise_en_main
-        premier_essai_prise_en_main? ? @evaluation.essais[1..] : @evaluation.essais
+        essais_verifies = @evaluation.essais_verifies
+        premier_essai_prise_en_main? ? essais_verifies[1..] : essais_verifies
       end
 
       def nombre_essais_sans_prise_en_main
@@ -32,7 +33,7 @@ module Evaluation
       end
 
       def premier_essai_prise_en_main?
-        premier_essai = @evaluation.essais.first
+        premier_essai = @evaluation.essais_verifies.first
         premier_essai.nombre_erreurs == 8 && premier_essai.nombre_de_non_remplissage == 7
       end
 

--- a/spec/models/evaluation/inventaire/comprehension_consigne_spec.rb
+++ b/spec/models/evaluation/inventaire/comprehension_consigne_spec.rb
@@ -18,7 +18,7 @@ describe Evaluation::Inventaire::ComprehensionConsigne do
     expect(evaluation).to receive(:nombre_essais_validation).and_return(1)
     expect(evaluation).to receive(:reussite?).and_return(false)
     expect(evaluation).to receive(:abandon?).and_return(true)
-    expect(evaluation).to receive(:essais).and_return([essai])
+    expect(evaluation).to receive(:essais_verifies).and_return([essai])
     expect(
       described_class.new(evaluation).niveau
     ).to eql(Competence::NIVEAU_1)

--- a/spec/models/evaluation/inventaire/perseverance_spec.rb
+++ b/spec/models/evaluation/inventaire/perseverance_spec.rb
@@ -10,7 +10,7 @@ describe Evaluation::Inventaire::Perseverance do
     expect(evaluation).to receive(:reussite?).and_return(reussite)
     essai = double
     allow(essai).to receive(:nombre_erreurs).and_return(erreurs)
-    allow(evaluation).to receive(:essais).and_return([essai])
+    allow(evaluation).to receive(:essais_verifies).and_return([essai])
     allow(evaluation).to receive(:nombre_essais_validation).and_return(nombre_essais)
     allow(evaluation).to receive(:temps_total).and_return(secondes)
     described_class.new(evaluation)

--- a/spec/models/evaluation/inventaire/vigilance_controle_spec.rb
+++ b/spec/models/evaluation/inventaire/vigilance_controle_spec.rb
@@ -35,7 +35,7 @@ describe Evaluation::Inventaire::VigilanceControle do
   it 'Réussite au 1er essai: niveau 4' do
     allow(evaluation).to receive(:reussite?).and_return(true)
     allow(evaluation).to receive(:nombre_essais_validation).and_return(1)
-    allow(evaluation).to receive(:essais).and_return([essai_reussite])
+    allow(evaluation).to receive(:essais_verifies).and_return([essai_reussite])
     expect(
       described_class.new(evaluation).niveau
     ).to eql(Competence::NIVEAU_4)
@@ -44,7 +44,7 @@ describe Evaluation::Inventaire::VigilanceControle do
   it 'Réussite au 2eme essai: lorsque le 1er essai comporte 7 non remplissage: niveau 4' do
     allow(evaluation).to receive(:reussite?).and_return(true)
     allow(evaluation).to receive(:nombre_essais_validation).and_return(2)
-    allow(evaluation).to receive(:essais).and_return([essai_de_prise_en_main, double])
+    allow(evaluation).to receive(:essais_verifies).and_return([essai_de_prise_en_main, double])
     expect(
       described_class.new(evaluation).niveau
     ).to eql(Competence::NIVEAU_4)
@@ -53,7 +53,7 @@ describe Evaluation::Inventaire::VigilanceControle do
   it 'Réussite avec des essais ne comprenant que des erreurs de non remplissage: niveau 3' do
     allow(evaluation).to receive(:reussite?).and_return(true)
     allow(evaluation).to receive(:nombre_essais_validation).and_return(9)
-    allow(evaluation).to receive(:essais).and_return(
+    allow(evaluation).to receive(:essais_verifies).and_return(
       [
         essai_de_prise_en_main,
         essai_avec_que_erreurs_de_non_remplissage(7),
@@ -75,7 +75,7 @@ describe Evaluation::Inventaire::VigilanceControle do
       et autres essais avec des erreurs de non remplissage: niveau 3' do
     allow(evaluation).to receive(:reussite?).and_return(true)
     allow(evaluation).to receive(:nombre_essais_validation).and_return(6)
-    allow(evaluation).to receive(:essais).and_return(
+    allow(evaluation).to receive(:essais_verifies).and_return(
       [
         essai_de_prise_en_main,
         essai_avec_que_erreurs_de_non_remplissage(7),
@@ -95,7 +95,7 @@ describe Evaluation::Inventaire::VigilanceControle do
       et autres essais avec des erreurs de non remplissage: niveau 2' do
     allow(evaluation).to receive(:reussite?).and_return(true)
     allow(evaluation).to receive(:nombre_essais_validation).and_return(6)
-    allow(evaluation).to receive(:essais).and_return(
+    allow(evaluation).to receive(:essais_verifies).and_return(
       [
         essai_de_prise_en_main,
         essai_avec_que_erreurs_de_non_remplissage(7),
@@ -114,7 +114,7 @@ describe Evaluation::Inventaire::VigilanceControle do
   it 'Réussite au 5eme essai rectifié en 4 fois : niveau 2' do
     allow(evaluation).to receive(:reussite?).and_return(true)
     allow(evaluation).to receive(:nombre_essais_validation).and_return(5)
-    allow(evaluation).to receive(:essais).and_return(
+    allow(evaluation).to receive(:essais_verifies).and_return(
       [
         essai_de_prise_en_main,
         essai_avec_erreurs(3),
@@ -131,7 +131,7 @@ describe Evaluation::Inventaire::VigilanceControle do
   it 'Abandon avec 2 essais et les mêmes erreurs aux essais: niveau 1' do
     allow(evaluation).to receive(:reussite?).and_return(false)
     allow(evaluation).to receive(:abandon?).and_return(true)
-    allow(evaluation).to receive(:essais).and_return(
+    allow(evaluation).to receive(:essais_verifies).and_return(
       [
         essai_de_prise_en_main,
         essai_avec_erreurs(3),
@@ -146,7 +146,7 @@ describe Evaluation::Inventaire::VigilanceControle do
   it "Abandon avec 3 essais une correction d'erreur: niveau indéterminé" do
     allow(evaluation).to receive(:reussite?).and_return(false)
     allow(evaluation).to receive(:abandon?).and_return(true)
-    allow(evaluation).to receive(:essais).and_return(
+    allow(evaluation).to receive(:essais_verifies).and_return(
       [
         essai_de_prise_en_main,
         essai_avec_erreurs(3),

--- a/spec/models/evaluation/inventaire_spec.rb
+++ b/spec/models/evaluation/inventaire_spec.rb
@@ -159,26 +159,56 @@ describe Evaluation::Inventaire do
     expect(evaluation.nombre_essais_validation).to eql(4)
   end
 
-  it 'retourne les essais avec le nombre de click et le temps' do
-    evenements = [
-      build(:evenement_demarrage, date: 10.minutes.ago),
-      build(:evenement_ouverture_contenant, date: 8.minutes.ago),
-      build(:evenement_ouverture_contenant, date: 8.minutes.ago),
-      build(:evenement_ouverture_contenant, date: 8.minutes.ago),
-      build(:evenement_saisie_inventaire, :echec, date: 7.minutes.ago),
-      build(:evenement_saisie_inventaire, :ok, date: 5.minutes.ago)
-    ]
-    evaluation = described_class.new(evenements)
-    expect(evaluation.essais.size).to eql(2)
-    evaluation.essais.first.tap do |essai|
-      expect(essai).to_not be_reussite
-      expect(essai.nombre_ouverture_contenant).to eql(3)
-      expect(essai.temps_total).to within(0.1).of(180)
+  describe '#essais_verifies' do
+    it 'retourne les essais verifiés avec le nombre de click et le temps' do
+      evenements = [
+        build(:evenement_demarrage, date: 10.minutes.ago),
+        build(:evenement_ouverture_contenant, date: 8.minutes.ago),
+        build(:evenement_ouverture_contenant, date: 8.minutes.ago),
+        build(:evenement_ouverture_contenant, date: 8.minutes.ago),
+        build(:evenement_saisie_inventaire, :echec, date: 7.minutes.ago),
+        build(:evenement_saisie_inventaire, :ok, date: 5.minutes.ago)
+      ]
+      evaluation = described_class.new(evenements)
+      expect(evaluation.essais_verifies.size).to eql(2)
+      evaluation.essais_verifies.first.tap do |essai|
+        expect(essai).to_not be_reussite
+        expect(essai.nombre_ouverture_contenant).to eql(3)
+        expect(essai.temps_total).to within(0.1).of(180)
+      end
+      evaluation.essais_verifies.last.tap do |essai|
+        expect(essai).to be_reussite
+        expect(essai.nombre_ouverture_contenant).to eql(0)
+        expect(essai.temps_total).to within(0.1).of(300)
+      end
     end
-    evaluation.essais.last.tap do |essai|
-      expect(essai).to be_reussite
-      expect(essai.nombre_ouverture_contenant).to eql(0)
-      expect(essai.temps_total).to within(0.1).of(300)
+
+    it 'retourne seulement les essais vérifiés' do
+      evenements = [
+        build(:evenement_demarrage, date: 10.minutes.ago),
+        build(:evenement_ouverture_contenant, date: 8.minutes.ago),
+        build(:evenement_saisie_inventaire, :echec, date: 7.minutes.ago),
+        build(:evenement_ouverture_contenant, date: 6.minutes.ago),
+        build(:evenement_saisie_inventaire, :echec, date: 5.minutes.ago),
+        build(:evenement_ouverture_contenant, date: 4.minutes.ago)
+      ]
+      evaluation = described_class.new(evenements)
+      expect(evaluation.essais_verifies.size).to eql(2)
+    end
+  end
+
+  describe '#essais' do
+    it 'retourne tout les essais même non vérifié' do
+      evenements = [
+        build(:evenement_demarrage, date: 10.minutes.ago),
+        build(:evenement_ouverture_contenant, date: 8.minutes.ago),
+        build(:evenement_saisie_inventaire, :echec, date: 7.minutes.ago),
+        build(:evenement_ouverture_contenant, date: 6.minutes.ago),
+        build(:evenement_saisie_inventaire, :echec, date: 5.minutes.ago),
+        build(:evenement_ouverture_contenant, date: 4.minutes.ago)
+      ]
+      evaluation = described_class.new(evenements)
+      expect(evaluation.essais.size).to eql(3)
     end
   end
 


### PR DESCRIPTION
Dans le cas d'un abandon, le dernier essai ne correspond pas a une
saisie d'inventaire, et nombre_erreurs renvoi nil.
Pour déterminer si la personne a fait des essais avec moins de 8
erreurs, on itère désormais sur tout les essais.

Fix #77 