### PR TITLE
Intégre Rollbar pour capturer les erreurs coté serveur

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,6 +16,7 @@ gem 'devise'
 gem 'mini_racer', '~> 0.2.0'
 gem 'pg', '~> 0.18'
 gem 'rack-cors', require: 'rack/cors'
+gem 'rollbar'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -181,6 +181,7 @@ GEM
       libv8 (>= 6.3)
     minitest (5.11.3)
     msgpack (1.2.6)
+    multi_json (1.13.1)
     nenv (0.3.0)
     nio4r (2.3.1)
     nokogiri (1.10.3)
@@ -242,6 +243,8 @@ GEM
     responders (2.4.1)
       actionpack (>= 4.2.0, < 6.0)
       railties (>= 4.2.0, < 6.0)
+    rollbar (2.20.1)
+      multi_json
     rspec (3.8.0)
       rspec-core (~> 3.8.0)
       rspec-expectations (~> 3.8.0)
@@ -345,6 +348,7 @@ DEPENDENCIES
   puma (~> 3.11)
   rack-cors
   rails (~> 5.2.2)
+  rollbar
   rspec-rails
   rspec_junit_formatter (~> 0.4.1)
   rubocop

--- a/config/initializers/rollbar.rb
+++ b/config/initializers/rollbar.rb
@@ -1,0 +1,71 @@
+Rollbar.configure do |config|
+  # Without configuration, Rollbar is enabled in all environments.
+  # To disable in specific environments, set config.enabled=false.
+
+  config.access_token = ENV['JETON_SERVEUR_ROLLBAR']
+
+  # Here we'll disable in 'test':
+  if Rails.env.test?
+    config.enabled = false
+  end
+
+  # By default, Rollbar will try to call the `current_user` controller method
+  # to fetch the logged-in user object, and then call that object's `id`
+  # method to fetch this property. To customize:
+  # config.person_method = "my_current_user"
+  # config.person_id_method = "my_id"
+
+  # Additionally, you may specify the following:
+  # config.person_username_method = "username"
+  # config.person_email_method = "email"
+
+  # If you want to attach custom data to all exception and message reports,
+  # provide a lambda like the following. It should return a hash.
+  # config.custom_data_method = lambda { {:some_key => "some_value" } }
+
+  # Add exception class names to the exception_level_filters hash to
+  # change the level that exception is reported at. Note that if an exception
+  # has already been reported and logged the level will need to be changed
+  # via the rollbar interface.
+  # Valid levels: 'critical', 'error', 'warning', 'info', 'debug', 'ignore'
+  # 'ignore' will cause the exception to not be reported at all.
+  # config.exception_level_filters.merge!('MyCriticalException' => 'critical')
+  #
+  # You can also specify a callable, which will be called with the exception instance.
+  # config.exception_level_filters.merge!('MyCriticalException' => lambda { |e| 'critical' })
+
+  # Enable asynchronous reporting (uses girl_friday or Threading if girl_friday
+  # is not installed)
+  # config.use_async = true
+  # Supply your own async handler:
+  # config.async_handler = Proc.new { |payload|
+  #  Thread.new { Rollbar.process_from_async_handler(payload) }
+  # }
+
+  # Enable asynchronous reporting (using sucker_punch)
+  # config.use_sucker_punch
+
+  # Enable delayed reporting (using Sidekiq)
+  # config.use_sidekiq
+  # You can supply custom Sidekiq options:
+  # config.use_sidekiq 'queue' => 'default'
+
+  # If your application runs behind a proxy server, you can set proxy parameters here.
+  # If https_proxy is set in your environment, that will be used. Settings here have precedence.
+  # The :host key is mandatory and must include the URL scheme (e.g. 'http://'), all other fields
+  # are optional.
+  #
+  # config.proxy = {
+  #   host: 'http://some.proxy.server',
+  #   port: 80,
+  #   user: 'username_if_auth_required',
+  #   password: 'password_if_auth_required'
+  # }
+
+  # If you run your staging application instance in production environment then
+  # you'll want to override the environment reported by `Rails.env` with an
+  # environment variable like this: `ROLLBAR_ENV=staging`. This is a recommended
+  # setup for Heroku. See:
+  # https://devcenter.heroku.com/articles/deploying-to-a-custom-rails-environment
+  config.environment = ENV['ROLLBAR_ENV'].presence || Rails.env
+end


### PR DESCRIPTION
Si la variable d'environnement JETON_SERVEUR_ROLLBAR est correctement défini, une erreur 500 sera envoyé à Rollbar.