### PR TITLE
Correction du calcul et de l'affichage de l'efficience 

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -7,6 +7,10 @@ module ApplicationHelper
     number_to_percentage(nombre, precision: 0)
   end
 
+  def progression_efficience(nombre)
+    nombre.is_a?(Symbol) ? 0 : nombre
+  end
+
   def rapport_colonne_class
     'col-4 px-5 mb-4'
   end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,9 +1,8 @@
 # frozen_string_literal: true
 
 module ApplicationHelper
-  def en_pourcentage(nombre)
-    indeterminee = I18n.t("admin.evaluations.evaluation.#{nombre}")
-    return indeterminee if nombre.is_a?(Symbol)
+  def formate_efficience(nombre)
+    return I18n.t("admin.evaluations.evaluation.#{nombre}") if nombre.is_a?(Symbol)
 
     number_to_percentage(nombre, precision: 0)
   end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -2,6 +2,9 @@
 
 module ApplicationHelper
   def en_pourcentage(nombre)
+    indeterminee = I18n.t("admin.evaluations.evaluation.#{nombre}")
+    return indeterminee if nombre.is_a?(Symbol)
+
     number_to_percentage(nombre, precision: 0)
   end
 

--- a/app/models/evaluation/base.rb
+++ b/app/models/evaluation/base.rb
@@ -63,14 +63,21 @@ module Evaluation
       competences_utilisees = competences.except(
         ::Competence::PERSEVERANCE,
         ::Competence::COMPREHENSION_CONSIGNE
-      ).reject do |_competence, niveau|
-        niveau == ::Competence::NIVEAU_INDETERMINE
-      end
-      return nil if competences_utilisees.size.zero?
+      )
+      return ::Competence::NIVEAU_INDETERMINE if competences_indeterminees?(competences_utilisees)
+      return 0 if competences_utilisees.size.zero?
 
       competences_utilisees.inject(0) do |memo, (_competence, niveau)|
         memo + CORRESPONDANCES_NIVEAUX[niveau]
       end / competences_utilisees.size
+    end
+
+    private
+
+    def competences_indeterminees?(competences)
+      competences.any? do |_competence, niveau|
+        niveau == ::Competence::NIVEAU_INDETERMINE
+      end
     end
   end
 end

--- a/app/models/evaluation/globale.rb
+++ b/app/models/evaluation/globale.rb
@@ -4,6 +4,8 @@ module Evaluation
   class Globale
     attr_reader :evaluations
 
+    NIVEAU_INDETERMINE = :indetermine
+
     def initialize(evaluations:)
       @evaluations = evaluations
     end
@@ -17,9 +19,11 @@ module Evaluation
     end
 
     def efficience
-      return nil if evaluations.blank?
+      return 0 if evaluations.blank?
 
       efficiences = evaluations.collect(&:efficience).compact
+      return NIVEAU_INDETERMINE if efficiences.include?(NIVEAU_INDETERMINE)
+
       efficiences.inject(0.0) { |somme, efficience| somme + efficience } / efficiences.size
     end
   end

--- a/app/views/admin/evaluation_globale/_controle.html.arb
+++ b/app/views/admin/evaluation_globale/_controle.html.arb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 div class: 'row controle' do
-  render 'badge', label: t('.efficience'), valeur: en_pourcentage(evaluation.efficience)
+  render 'badge', label: t('.efficience'), valeur: formate_efficience(evaluation.efficience)
   render 'badge', label: t('.nombre_trop_tard'), valeur: evaluation.nombre_non_triees
   render 'badge', label: t('.nombre_erreurs'), valeur: evaluation.nombre_mal_placees
   render 'badge', label: t('.arret_au'), valeur: evaluation.nombre_pieces

--- a/app/views/admin/evaluation_globale/_evaluation_globale.html.arb
+++ b/app/views/admin/evaluation_globale/_evaluation_globale.html.arb
@@ -8,7 +8,7 @@ div class: :panel do
 
   h2 class: 'text-center' do
     span class: 'btn btn-info btn-lg' do
-      t('.efficience_globale', efficience: en_pourcentage(evaluation_globale.efficience))
+      t('.efficience_globale', efficience: formate_efficience(evaluation_globale.efficience))
     end
   end
 
@@ -21,7 +21,7 @@ div class: :panel do
           efficience = evaluation.efficience
           div class: 'progress-bar', role: 'progressbar', style: "width: #{efficience}%",
               'aria-valuemin': 0, 'aria-valuemax': 100, 'aria-valuenow': efficience do
-            en_pourcentage(efficience).to_s
+            formate_efficience(efficience).to_s
           end
         end
       end

--- a/app/views/admin/evaluation_globale/_evaluation_globale.html.arb
+++ b/app/views/admin/evaluation_globale/_evaluation_globale.html.arb
@@ -21,7 +21,7 @@ div class: :panel do
           efficience = evaluation.efficience
           div class: 'progress-bar', role: 'progressbar', style: "width: #{efficience}%",
               'aria-valuemin': 0, 'aria-valuemax': 100, 'aria-valuenow': efficience do
-            "#{efficience}%"
+            en_pourcentage(efficience).to_s
           end
         end
       end

--- a/app/views/admin/evaluation_globale/_evaluation_globale.html.arb
+++ b/app/views/admin/evaluation_globale/_evaluation_globale.html.arb
@@ -18,10 +18,10 @@ div class: :panel do
       div class: "#{rapport_colonne_class} #{situation}" do
         div t('.situation', situation: t(".#{situation}"))
         div class: :progress do
-          efficience = evaluation.efficience
+          efficience = progression_efficience(evaluation.efficience)
           div class: 'progress-bar', role: 'progressbar', style: "width: #{efficience}%",
               'aria-valuemin': 0, 'aria-valuemax': 100, 'aria-valuenow': efficience do
-            formate_efficience(efficience).to_s
+            formate_efficience(evaluation.efficience)
           end
         end
       end

--- a/app/views/admin/evaluation_globale/_inventaire.html.arb
+++ b/app/views/admin/evaluation_globale/_inventaire.html.arb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 div class: 'row inventaire' do
-  render 'badge', label: t('.efficience'), valeur: en_pourcentage(evaluation.efficience)
+  render 'badge', label: t('.efficience'), valeur: formate_efficience(evaluation.efficience)
   render 'badge', label: t('.duree'), valeur: distance_of_time_in_words(evaluation.temps_total)
   render 'badge', label: t('.nombre_essais'), valeur: evaluation.nombre_essais_validation
 end

--- a/app/views/admin/evaluation_globale/_tri.html.arb
+++ b/app/views/admin/evaluation_globale/_tri.html.arb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 div class: 'row tri' do
-  render 'badge', label: t('.efficience'), valeur: en_pourcentage(evaluation.efficience)
+  render 'badge', label: t('.efficience'), valeur: formate_efficience(evaluation.efficience)
   render 'badge', label: t('.duree'), valeur: distance_of_time_in_words(evaluation.temps_total)
   render 'badge', label: t('.nombre_erreurs'), valeur: evaluation.nombre_mal_placees
   render 'badge', label: t('.reste_plateau'), valeur: evaluation.nombre_non_triees

--- a/app/views/admin/evaluations/_evaluation_competences.html.arb
+++ b/app/views/admin/evaluations/_evaluation_competences.html.arb
@@ -5,6 +5,6 @@ panel t('.titre') do
     evaluation.competences.each do |competence, niveau|
       row(t(".#{competence}")) { niveau }
     end
-    row(t('.efficience')) { "#{evaluation.efficience}%" }
+    row(t('.efficience')) { en_pourcentage(evaluation.efficience) }
   end
 end

--- a/app/views/admin/evaluations/_evaluation_competences.html.arb
+++ b/app/views/admin/evaluations/_evaluation_competences.html.arb
@@ -5,6 +5,6 @@ panel t('.titre') do
     evaluation.competences.each do |competence, niveau|
       row(t(".#{competence}")) { niveau }
     end
-    row(t('.efficience')) { en_pourcentage(evaluation.efficience) }
+    row(t('.efficience')) { formate_efficience(evaluation.efficience) }
   end
 end

--- a/config/locales/views/evaluations.yml
+++ b/config/locales/views/evaluations.yml
@@ -57,6 +57,7 @@ fr:
         abandon: Abandon
         echec: Échec
         termine: Terminé
+        indetermine: Indéterminée
       evaluation_inventaire:
         ouverture_contenant: Ouvertures de contenant
         essai: Essai %{count}

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -13,4 +13,14 @@ describe ApplicationHelper do
         .to eql(I18n.t('admin.evaluations.evaluation.indetermine'))
     end
   end
+
+  describe '#progression_efficience' do
+    it 'retourne la valeur' do
+      expect(helper.progression_efficience(5.3)).to eql(5.3)
+    end
+
+    it "retourne 0 si l'efficience est indéterminée" do
+      expect(helper.progression_efficience(::Competence::NIVEAU_INDETERMINE)).to eql(0)
+    end
+  end
 end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe ApplicationHelper do
+  describe '#formate_efficience' do
+    it 'retourne le pourcentage arrondi' do
+      expect(helper.formate_efficience(5.3)).to eql('5%')
+    end
+
+    it 'retourne la chaine indéterminé traduite' do
+      expect(helper.formate_efficience(::Competence::NIVEAU_INDETERMINE))
+        .to eql(I18n.t('admin.evaluations.evaluation.indetermine'))
+    end
+  end
+end

--- a/spec/models/evaluation/base_spec.rb
+++ b/spec/models/evaluation/base_spec.rb
@@ -50,18 +50,18 @@ describe Evaluation::Base do
       expect(evaluation.efficience).to eql(91)
     end
 
-    it 'ignore les compétences qui ont un niveau indéterminée' do
+    it 'retourne une efficience indéterminé si une compétences indéterminé' do
       expect(evaluation).to receive(:competences).and_return(
         ::Competence::RAPIDITE => Competence::NIVEAU_1,
         ::Competence::COMPARAISON_TRI => Competence::NIVEAU_INDETERMINE,
         ::Competence::ATTENTION_CONCENTRATION => Competence::NIVEAU_2
       )
-      expect(evaluation.efficience).to eql(37)
+      expect(evaluation.efficience).to eql(::Competence::NIVEAU_INDETERMINE)
     end
 
-    it "retourne nil lorsque rien n'a été mesuré" do
+    it "retourne 0 lorsque rien n'a été mesuré" do
       expect(evaluation).to receive(:competences).and_return({})
-      expect(evaluation.efficience).to be_nil
+      expect(evaluation.efficience).to eql(0)
     end
   end
 

--- a/spec/models/evaluation/globale_spec.rb
+++ b/spec/models/evaluation/globale_spec.rb
@@ -19,7 +19,7 @@ describe Evaluation::Globale do
   describe '#efficience est la moyenne des efficiences' do
     context "sans evaluation c'est incalculable" do
       let(:evaluations) { [] }
-      it { expect(evaluation_globale.efficience).to eq(nil) }
+      it { expect(evaluation_globale.efficience).to eq(0) }
     end
 
     context 'une evaluation: son efficience' do
@@ -32,9 +32,11 @@ describe Evaluation::Globale do
       it { expect(evaluation_globale.efficience).to eq(17.5) }
     end
 
-    context 'ignore les évaluations vides' do
-      let(:evaluations) { [double(efficience: 20), double(efficience: nil)] }
-      it { expect(evaluation_globale.efficience).to eq(20) }
+    context 'retourne une efficience indéterminée si une situation est indéterminé' do
+      let(:evaluations) do
+        [double(efficience: 20), double(efficience: ::Evaluation::Globale::NIVEAU_INDETERMINE)]
+      end
+      it { expect(evaluation_globale.efficience).to eq(::Evaluation::Globale::NIVEAU_INDETERMINE) }
     end
   end
 end


### PR DESCRIPTION
Lorsqu'une des compétences spécifique a une situation est indéterminé, l'efficience de la situation est désormais indéterminé. En conséquence dans le rapport global, l'efficience sera également indéterminée.

Voici le résultat avec une situation en indéterminée:

![Screenshot_2019-07-01 Evaluation Globale Compétences Pro Serveur](https://user-images.githubusercontent.com/86659/60453729-36036200-9c32-11e9-9c79-e2e999c02808.png)

Fix #80.
