### PR TITLE
Formatte les durées sans approximations.

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -11,6 +11,10 @@ module ApplicationHelper
     nombre.is_a?(Symbol) ? 0 : nombre
   end
 
+  def formate_duree(duree)
+    Time.at(duree).utc.strftime(duree < 1.hour ? '%M:%S' : '%H:%M:%S')
+  end
+
   def rapport_colonne_class
     'col-4 px-5 mb-4'
   end

--- a/app/views/admin/evaluation_globale/_inventaire.html.arb
+++ b/app/views/admin/evaluation_globale/_inventaire.html.arb
@@ -2,6 +2,6 @@
 
 div class: 'row inventaire' do
   render 'badge', label: t('.efficience'), valeur: formate_efficience(evaluation.efficience)
-  render 'badge', label: t('.duree'), valeur: distance_of_time_in_words(evaluation.temps_total)
+  render 'badge', label: t('.duree'), valeur: formate_duree(evaluation.temps_total)
   render 'badge', label: t('.nombre_essais'), valeur: evaluation.nombre_essais_validation
 end

--- a/app/views/admin/evaluation_globale/_tri.html.arb
+++ b/app/views/admin/evaluation_globale/_tri.html.arb
@@ -2,7 +2,7 @@
 
 div class: 'row tri' do
   render 'badge', label: t('.efficience'), valeur: formate_efficience(evaluation.efficience)
-  render 'badge', label: t('.duree'), valeur: distance_of_time_in_words(evaluation.temps_total)
+  render 'badge', label: t('.duree'), valeur: formate_duree(evaluation.temps_total)
   render 'badge', label: t('.nombre_erreurs'), valeur: evaluation.nombre_mal_placees
   render 'badge', label: t('.reste_plateau'), valeur: evaluation.nombre_non_triees
 end

--- a/app/views/admin/evaluations/_informations_generales_sidebar.html.arb
+++ b/app/views/admin/evaluations/_informations_generales_sidebar.html.arb
@@ -14,6 +14,6 @@ attributes_table_for resource do
     end
   end
   row(t('admin.evaluations.evaluation.temps')) do |evaluation|
-    distance_of_time_in_words(evaluation.temps_total)
+    formate_duree(evaluation.temps_total)
   end
 end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -23,4 +23,18 @@ describe ApplicationHelper do
       expect(helper.progression_efficience(::Competence::NIVEAU_INDETERMINE)).to eql(0)
     end
   end
+
+  describe '#formate_duree' do
+    it 'retourne la durée en minutes et secondes' do
+      expect(helper.formate_duree(60)).to eql('01:00')
+    end
+
+    it 'retourne une autre durée en minutes et secondes' do
+      expect(helper.formate_duree(30)).to eql('00:30')
+    end
+
+    it 'retourne une durée en heure, minutes et secondes' do
+      expect(helper.formate_duree(3661)).to eql('01:01:01')
+    end
+  end
 end


### PR DESCRIPTION
Les durées de passation étaient sympa mais on manque de précision. Désormais on affiche la durée quasi brut, avec l'heure (si pertinent), minutes et secondes.

![Screenshot_2019-07-02 234eebad-f714-4458-9363-29d41aacd460 Compétences Pro Serveur](https://user-images.githubusercontent.com/86659/60503845-c5efed00-9cc0-11e9-9e05-df6e7ce4ff08.png)
