### PR TITLE
désactive l'encapsulation des paramètres

### DIFF
--- a/config/initializers/wrap_parameters.rb
+++ b/config/initializers/wrap_parameters.rb
@@ -4,9 +4,9 @@
 # is enabled by default.
 
 # Enable parameter wrapping for JSON. You can disable this by setting :format to an empty array.
-ActiveSupport.on_load(:action_controller) do
-  wrap_parameters format: [:json]
-end
+# ActiveSupport.on_load(:action_controller) do
+#   wrap_parameters format: [:json]
+# end
 
 # To enable root element in JSON for ActiveRecord objects.
 # ActiveSupport.on_load(:active_record) do


### PR DESCRIPTION
cette PR empêche Rails d'encapsuler les paramètres dans un nouvel attribut et d'avoir des doublons.

Voici ce qu'on avait avant : 
```
{"date"=>1562578163092, "session_id"=>"15e3d10c-75a8-478c-a833-f619dbc396a4", "situation"=>"tri", "nom"=>"demarrage", "donnees"=>{}, "utilisateur"=>"Stéphane", "evenement"=>{"nom"=>"demarrage", "donnees"=>{}, "date"=>1562578163092, "session_id"=>"15e3d10c-75a8-478c-a833-f619dbc396a4", "utilisateur"=>"Stéphane"}}
```

avec cette PR, on aura ça 👍 
```
{"date"=>1562578163092, "session_id"=>"15e3d10c-75a8-478c-a833-f619dbc396a4", "situation"=>"tri", "nom"=>"demarrage", "donnees"=>{}, "utilisateur"=>"Stéphane"}
```