### PR TITLE
Ne valide pas les événements dans la migration.

### DIFF
--- a/db/migrate/20190705103701_affecte_les_situations_aux_evenements.rb
+++ b/db/migrate/20190705103701_affecte_les_situations_aux_evenements.rb
@@ -6,7 +6,7 @@ class AffecteLesSituationsAuxEvenements < ActiveRecord::Migration[5.2]
         situation.libelle = nom_technique
       end
       evenement.situation = situation
-      evenement.save!(validate: false)
+      evenement.save(validate: false)
     end
   end
 end

--- a/db/migrate/20190705103701_affecte_les_situations_aux_evenements.rb
+++ b/db/migrate/20190705103701_affecte_les_situations_aux_evenements.rb
@@ -6,7 +6,7 @@ class AffecteLesSituationsAuxEvenements < ActiveRecord::Migration[5.2]
         situation.libelle = nom_technique
       end
       evenement.situation = situation
-      evenement.save!
+      evenement.save!(validate: false)
     end
   end
 end


### PR DESCRIPTION
La relation evaluation est devenu obligatoire mais la migration n'est
pas encore écrite. Du coup la validation casse lorsqu'on sauve les événements.