### PR TITLE
Relie campagne et evaluation

### DIFF
--- a/app/admin/evaluation.rb
+++ b/app/admin/evaluation.rb
@@ -6,6 +6,7 @@ ActiveAdmin.register Evaluation do
   index do
     selectable_column
     column :nom
+    column :campagne
     column :created_at
     column '' do |evaluation|
       span link_to t('.restitution'),

--- a/app/models/campagne.rb
+++ b/app/models/campagne.rb
@@ -3,4 +3,8 @@
 class Campagne < ApplicationRecord
   validates :libelle, presence: true
   validates :code, presence: true, uniqueness: true
+
+  def display_name
+    libelle
+  end
 end

--- a/app/models/evaluation.rb
+++ b/app/models/evaluation.rb
@@ -2,4 +2,5 @@
 
 class Evaluation < ApplicationRecord
   validates :nom, presence: true
+  belongs_to :campagne
 end

--- a/app/params/evaluation_params.rb
+++ b/app/params/evaluation_params.rb
@@ -1,9 +1,23 @@
 # frozen_string_literal: true
 
 class EvaluationParams
-  def self.from(params)
-    params.permit(
-      :nom
-    )
+  class << self
+    def from(params)
+      permitted = params.permit(
+        :nom,
+        :code_campagne
+      )
+      relie_campagne!(permitted)
+      permitted
+    end
+
+    private
+
+    def relie_campagne!(params)
+      code_campagne = params.delete('code_campagne')
+      campagne = Campagne.find_by code: code_campagne
+      campagne ||= Campagne.first
+      params['campagne'] = campagne
+    end
   end
 end

--- a/db/migrate/20190708130334_add_campagne_to_evaluation.rb
+++ b/db/migrate/20190708130334_add_campagne_to_evaluation.rb
@@ -1,0 +1,5 @@
+class AddCampagneToEvaluation < ActiveRecord::Migration[5.2]
+  def change
+    add_reference :evaluations, :campagne, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_07_08_124645) do
+ActiveRecord::Schema.define(version: 2019_07_08_130334) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -52,6 +52,8 @@ ActiveRecord::Schema.define(version: 2019_07_08_124645) do
     t.string "nom"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "campagne_id"
+    t.index ["campagne_id"], name: "index_evaluations_on_campagne_id"
   end
 
   create_table "evenements", force: :cascade do |t|
@@ -75,5 +77,6 @@ ActiveRecord::Schema.define(version: 2019_07_08_124645) do
     t.datetime "updated_at", null: false
   end
 
+  add_foreign_key "evaluations", "campagnes"
   add_foreign_key "evenements", "situations"
 end

--- a/spec/factories/campagne.rb
+++ b/spec/factories/campagne.rb
@@ -2,5 +2,7 @@
 
 FactoryBot.define do
   factory :campagne do
+    libelle { 'Ma campagne' }
+    code { '123DB' }
   end
 end

--- a/spec/factories/evaluation.rb
+++ b/spec/factories/evaluation.rb
@@ -3,5 +3,6 @@
 FactoryBot.define do
   factory :evaluation do
     nom { 'Roger' }
+    campagne
   end
 end

--- a/spec/models/evaluation_spec.rb
+++ b/spec/models/evaluation_spec.rb
@@ -4,4 +4,5 @@ require 'rails_helper'
 
 describe Evaluation do
   it { should validate_presence_of :nom }
+  it { should belong_to :campagne }
 end

--- a/spec/params/evaluation_params_spec.rb
+++ b/spec/params/evaluation_params_spec.rb
@@ -12,7 +12,7 @@ describe EvaluationParams do
 
       evaluation_params = described_class.from(params)
       expect(evaluation_params.keys.sort).to eql(
-        %w[nom]
+        %w[campagne nom]
       )
     end
   end

--- a/spec/requests/evaluations_spec.rb
+++ b/spec/requests/evaluations_spec.rb
@@ -4,17 +4,29 @@ require 'rails_helper'
 
 describe 'Evaluation API', type: :request do
   describe 'POST /evaluations' do
-    context 'Quand une requête est valide' do
-      let(:payload_valide) { { nom: 'Roger' } }
+    let!(:campagne) { create :campagne }
 
-      it 'Crée une évaluation' do
-        expect { post '/api/evaluations', params: payload_valide }
-          .to change { Evaluation.count }.by(1)
+    context 'Quand une requête est valide' do
+      context 'sans code campagne' do
+        let(:payload_valide) { { nom: 'Roger' } }
+
+        it 'Crée une évaluation avec la première campagne' do
+          expect { post '/api/evaluations', params: payload_valide }
+            .to change { Evaluation.count }.by(1)
+          expect(Evaluation.last.campagne).to eq campagne
+        end
+
+        it 'retourne une 201' do
+          post '/api/evaluations', params: payload_valide
+          expect(response).to have_http_status(201)
+        end
       end
 
-      it 'retourne une 201' do
-        post '/api/evaluations', params: payload_valide
-        expect(response).to have_http_status(201)
+      context 'avec code campagne' do
+        let!(:campagne_ete19) { create :campagne, code: 'ETE19' }
+        let(:paylod_valide_avec_campagne) { { nom: 'Roger', code_campagne: 'ETE19' } }
+        before { post '/api/evaluations', params: paylod_valide_avec_campagne }
+        it { expect(Evaluation.last.campagne).to eq campagne_ete19 }
       end
     end
 


### PR DESCRIPTION
contribue à #88 

Relie les évaluations à une campagne. Accepte de recevoir un `code_campagne` pour une prochaine étape côté client.

 ⚠️ Avec cette PR, il est obligatoire d'avoir au moins une campagne dans la base de données pour que ça fonctionne.
