### PR TITLE
Associe les anciens événements à des évaluations

### DIFF
--- a/app/models/restitution/base.rb
+++ b/app/models/restitution/base.rb
@@ -15,7 +15,7 @@ module Restitution
     }.freeze
 
     attr_reader :evenements
-    delegate :session_id, :utilisateur, :situation, :date, to: :premier_evenement
+    delegate :session_id, :situation, :date, to: :premier_evenement
 
     def initialize(evenements)
       @evenements = evenements

--- a/app/views/admin/evenements/_index.html.arb
+++ b/app/views/admin/evenements/_index.html.arb
@@ -2,7 +2,6 @@
 
 context.instance_eval do
   selectable_column
-  column :utilisateur
   column :session_id
   column :situation
   column :nom

--- a/db/migrate/20190709072254_affecte_evaluation_aux_evenements.rb
+++ b/db/migrate/20190709072254_affecte_evaluation_aux_evenements.rb
@@ -1,0 +1,9 @@
+class AffecteEvaluationAuxEvenements < ActiveRecord::Migration[5.2]
+  def change
+    Evenement.select(:utilisateur).distinct.each do |evenement|
+      next if evenement.utilisateur.nil?
+      evaluation = Evaluation.create(nom: evenement.utilisateur)
+      Evenement.where(utilisateur: evenement.utilisateur).update_all(evaluation_id: evaluation.id)
+    end
+  end
+end

--- a/db/migrate/20190709075503_supprime_colonne_utilisateur.rb
+++ b/db/migrate/20190709075503_supprime_colonne_utilisateur.rb
@@ -1,0 +1,5 @@
+class SupprimeColonneUtilisateur < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :evenements, :utilisateur, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_07_08_130334) do
+ActiveRecord::Schema.define(version: 2019_07_09_075503) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -63,9 +63,8 @@ ActiveRecord::Schema.define(version: 2019_07_08_130334) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "session_id"
-    t.string "utilisateur"
-    t.bigint "situation_id"
     t.bigint "evaluation_id"
+    t.bigint "situation_id"
     t.index ["evaluation_id"], name: "index_evenements_on_evaluation_id"
     t.index ["situation_id"], name: "index_evenements_on_situation_id"
   end


### PR DESCRIPTION
Les ancien événements  avec un utilisateur sans évaluation sont désormais migrés. Et la colonne utilisateur supprimé !

Fix #97 