### PR TITLE
Ajoute traductions pour Campagne et Evaluation

### DIFF
--- a/config/locales/models/campagne.yml
+++ b/config/locales/models/campagne.yml
@@ -1,19 +1,19 @@
 fr:
   activerecord:
     attributes:
-      situation:
+      campagne:
         created_at: Créée le
         updated_at: Mise à jour le
         libelle: Libellé
   formtastic:
     actions:
-      situation:
+      campagne:
         create: Créer
         update: Enregistrer
   active_admin:
     resources:
-      situation:
+      campagne:
         delete_model: Supprimer
-        new_model: Créer une situation
+        new_model: Créer une campagne
         edit_model: Modifier
         delete_model: Supprimer

--- a/config/locales/models/evaluation.yml
+++ b/config/locales/models/evaluation.yml
@@ -1,0 +1,15 @@
+fr:
+  activerecord:
+    models:
+      evaluation:
+        one: Évaluation
+        other: Évaluations
+    attributes:
+      evaluation:
+        created_at: Créée le
+        updated_at: Mise à jour le
+        libelle: Libellé
+  active_admin:
+    resources:
+      evaluation:
+        delete_model: Supprimer


### PR DESCRIPTION
On avait des traductions manquantes sur plusieurs modèles notamment Campagne et Evaluation