### PR TITLE
Corrige l'espace de nom utilisé dans la restitution globale.

### DIFF
--- a/config/locales/views/restitutions.yml
+++ b/config/locales/views/restitutions.yml
@@ -18,7 +18,7 @@ fr:
       restitution_globale:
         situation: 'Situation %{situation}'
         efficience_globale: "Efficience globale : %{efficience}"
-      evaluation_competence:
+      restitution_competence:
         indetermine: non obs.
         1: 1
         2: 2


### PR DESCRIPTION
Dans #90 j'avais oublié de changer une clef de trad, et je l'ai raté dans mes tests.