### PR TITLE
Permet de configurer un questionnaire pour une campagne

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,7 +42,7 @@ group :test do
   gem 'launchy'
   gem 'rubocop', require: false
   gem 'rubocop-rspec', require: false
-  gem 'shoulda-matchers', '~> 3.0'
+  gem 'shoulda-matchers'
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,7 @@ gem 'puma', '~> 3.11'
 # Reduces boot times through caching; required in config/boot.rb
 gem 'activeadmin'
 gem 'activeadmin_addons'
+gem 'activeadmin_json_editor'
 gem 'bootsnap', '>= 1.1.0', require: false
 gem 'bootstrap', '~> 4.3', '>= 4.3.1'
 gem 'coffee-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,7 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    ace-rails-ap (4.2)
     actioncable (5.2.2)
       actionpack (= 5.2.2)
       nio4r (~> 2.0)
@@ -44,6 +45,9 @@ GEM
       sass
       select2-rails (~> 4.0)
       xdan-datetimepicker-rails (~> 2.5.1)
+    activeadmin_json_editor (0.0.9)
+      ace-rails-ap
+      railties (>= 3.0)
     activejob (5.2.2)
       activesupport (= 5.2.2)
       globalid (>= 0.3.6)
@@ -347,6 +351,7 @@ PLATFORMS
 DEPENDENCIES
   activeadmin
   activeadmin_addons
+  activeadmin_json_editor
   bootsnap (>= 1.1.0)
   bootstrap (~> 4.3, >= 4.3.1)
   byebug

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -310,8 +310,8 @@ GEM
     select2-rails (4.0.3)
       thor (~> 0.14)
     shellany (0.0.1)
-    shoulda-matchers (3.1.3)
-      activesupport (>= 4.0.0)
+    shoulda-matchers (4.1.0)
+      activesupport (>= 4.2.0)
     spring (2.0.2)
       activesupport (>= 4.2)
     spring-watcher-listen (2.0.1)
@@ -373,7 +373,7 @@ DEPENDENCIES
   rspec_junit_formatter (~> 0.4.1)
   rubocop
   rubocop-rspec
-  shoulda-matchers (~> 3.0)
+  shoulda-matchers
   spring
   spring-watcher-listen (~> 2.0.0)
   tzinfo-data

--- a/app/admin/campagnes.rb
+++ b/app/admin/campagnes.rb
@@ -1,9 +1,19 @@
 # frozen_string_literal: true
 
 ActiveAdmin.register Campagne do
-  permit_params :libelle, :code
+  permit_params :libelle, :code, :questionnaire_id
 
   show do
     render partial: 'show', locals: { evaluations: resource.evaluations }
+  end
+
+  form do |f|
+    f.semantic_errors
+    f.inputs do
+      f.input :libelle
+      f.input :code
+      f.input :questionnaire
+    end
+    f.actions
   end
 end

--- a/app/admin/questionnaires.rb
+++ b/app/admin/questionnaires.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+ActiveAdmin.register Questionnaire do
+  permit_params :libelle, :questions
+end

--- a/app/models/campagne.rb
+++ b/app/models/campagne.rb
@@ -2,6 +2,8 @@
 
 class Campagne < ApplicationRecord
   has_many :evaluations
+  belongs_to :questionnaire, optional: true
+
   validates :libelle, presence: true
   validates :code, presence: true, uniqueness: true
   before_validation :genere_code_unique

--- a/app/models/questionnaire.rb
+++ b/app/models/questionnaire.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class Questionnaire < ApplicationRecord
+  validates :libelle, :questions, presence: true
+
+  def display_name
+    libelle
+  end
+end

--- a/app/views/admin/campagnes/_show.html.arb
+++ b/app/views/admin/campagnes/_show.html.arb
@@ -5,6 +5,7 @@ panel 'Détails de la campagne' do
     row :id
     row :libelle
     row :code
+    row :questionnaire
     row :created_at
   end
 end

--- a/config/initializers/active_admin.rb
+++ b/config/initializers/active_admin.rb
@@ -198,9 +198,12 @@ ActiveAdmin.setup do |config|
   # You can provide an options hash for more control, which is passed along to stylesheet_link_tag():
     config.register_stylesheet 'restitution_globale.css'
     config.register_stylesheet 'restitution_globale_print.css', media: :print
+    config.register_stylesheet 'active_admin/json_editor.css'
+
   #
   # To load a javascript file:
   #   config.register_javascript 'my_javascript.js'
+  config.register_javascript 'active_admin/json_editor.js'
 
   # == CSV options
   #

--- a/db/migrate/20190712145515_create_questionnaires.rb
+++ b/db/migrate/20190712145515_create_questionnaires.rb
@@ -1,0 +1,10 @@
+class CreateQuestionnaires < ActiveRecord::Migration[5.2]
+  def change
+    create_table :questionnaires do |t|
+      t.string :libelle
+      t.jsonb :questions
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20190712151122_add_questionnaire_to_campagne.rb
+++ b/db/migrate/20190712151122_add_questionnaire_to_campagne.rb
@@ -1,0 +1,5 @@
+class AddQuestionnaireToCampagne < ActiveRecord::Migration[5.2]
+  def change
+    add_reference :campagnes, :questionnaire, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_07_12_145515) do
+ActiveRecord::Schema.define(version: 2019_07_12_151122) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -46,6 +46,8 @@ ActiveRecord::Schema.define(version: 2019_07_12_145515) do
     t.string "code"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "questionnaire_id"
+    t.index ["questionnaire_id"], name: "index_campagnes_on_questionnaire_id"
   end
 
   create_table "evaluations", force: :cascade do |t|
@@ -83,6 +85,7 @@ ActiveRecord::Schema.define(version: 2019_07_12_145515) do
     t.datetime "updated_at", null: false
   end
 
+  add_foreign_key "campagnes", "questionnaires"
   add_foreign_key "evaluations", "campagnes"
   add_foreign_key "evenements", "situations"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_07_09_075503) do
+ActiveRecord::Schema.define(version: 2019_07_12_145515) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -63,10 +63,17 @@ ActiveRecord::Schema.define(version: 2019_07_09_075503) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "session_id"
-    t.bigint "evaluation_id"
     t.bigint "situation_id"
+    t.bigint "evaluation_id"
     t.index ["evaluation_id"], name: "index_evenements_on_evaluation_id"
     t.index ["situation_id"], name: "index_evenements_on_situation_id"
+  end
+
+  create_table "questionnaires", force: :cascade do |t|
+    t.string "libelle"
+    t.jsonb "questions"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "situations", force: :cascade do |t|

--- a/spec/factories/questionnaire.rb
+++ b/spec/factories/questionnaire.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :questionnaire do
+    libelle { 'Mon Questionnaire' }
+    questions { [{}] }
+  end
+end

--- a/spec/features/campagne_spec.rb
+++ b/spec/features/campagne_spec.rb
@@ -16,16 +16,22 @@ describe 'Admin - Campagne', type: :feature do
   end
 
   describe 'création' do
+    let!(:questionnaire) { create :questionnaire, libelle: 'Mon QCM' }
     before do
       visit new_admin_campagne_path
       fill_in :campagne_libelle, with: 'Belfort, pack demandeur'
     end
 
     context 'génère un code si on en saisit pas' do
-      before { fill_in :campagne_code, with: '' }
+      before do
+        fill_in :campagne_code, with: ''
+        select 'Mon QCM'
+      end
+
       it do
         expect { click_on 'Créer' }.to(change { Campagne.count })
         expect(Campagne.last.code).to be_present
+        expect(page).to have_content 'Mon QCM'
       end
     end
 

--- a/spec/features/questionnaire_spec.rb
+++ b/spec/features/questionnaire_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe 'Admin - Questionnaire', type: :feature do
+  before { se_connecter_comme_administrateur }
+  let!(:questionnaire) { create :questionnaire, libelle: 'Numératie et Litératie' }
+
+  describe 'index' do
+    before { visit admin_questionnaires_path }
+    it do
+      expect(page).to have_content 'Numératie et Litératie'
+    end
+  end
+
+  describe 'création' do
+    before do
+      visit new_admin_questionnaire_path
+      fill_in :questionnaire_libelle, with: 'Evaluation Formation'
+      fill_in :questionnaire_questions, with: "[{q: 'question1'}]"
+    end
+
+    it do
+      expect { click_on 'Créer' }.to(change { Questionnaire.count })
+      expect(page).to have_content "[{q: 'question1'}]"
+    end
+  end
+end

--- a/spec/models/campagne_spec.rb
+++ b/spec/models/campagne_spec.rb
@@ -5,6 +5,7 @@ require 'rails_helper'
 RSpec.describe Campagne, type: :model do
   it { should validate_presence_of :libelle }
   it { should validate_uniqueness_of :code }
+  it { should belong_to(:questionnaire).optional }
 
   describe 'validation du code' do
     context 'garde le code initial' do

--- a/spec/models/questionnaire_spec.rb
+++ b/spec/models/questionnaire_spec.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Questionnaire, type: :model do
+  it { should validate_presence_of :libelle }
+  it { should validate_presence_of :questions }
+end


### PR DESCRIPTION
Contribue à #88 et est liée à betagouv/competences-pro#385

L'idée c'est que le serveur renvoie les données du questionnaire en fonction de la campagne courante. Cette PR permet de créer des questionnaires et des les relier aux campagnes.
![Capture d’écran 2019-07-12 à 17 26 49](https://user-images.githubusercontent.com/28393/61139746-42a57700-a4ca-11e9-9150-0849ffcf1d9d.png)
![Capture d’écran 2019-07-12 à 17 26 56](https://user-images.githubusercontent.com/28393/61139747-433e0d80-a4ca-11e9-8f56-33311c37a28d.png)

