### PR TITLE
Ajoute un GET sur l'évaluation pour récupérer les questions

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ accessible à l'url `/admin`, un compte admin est créé avec l'execution du see
 
 L'api est accessible au point `/api`
 
-### Évaluation
+### Crée une évaluation
 
 **Requête**
 
@@ -34,7 +34,8 @@ L'api est accessible au point `/api`
 
 ```
 {
-  "nom": "Roger"
+  "nom": "Roger",
+  "code_campagne": "Mon code de campagne"
 }
 ```
 
@@ -47,7 +48,29 @@ L'api est accessible au point `/api`
 }
 ```
 
-### Événements
+### Récupére des informations sur l'évaluation
+
+**Requête**
+
+`GET /api/evaluations/:id`
+
+**Réponse**
+
+```
+{
+  "questions:": [
+    {
+      id: 1,
+      type: 'qcm',
+      intitule: 'Ma question',
+      description: 'Ma description',
+      choix: []
+    }
+  ]
+}
+```
+
+### Crée un événement
 
 `POST /api/evenements`
 
@@ -60,7 +83,7 @@ Contenu:
   "session_id": "baf2c86c-6c34-11e9-901c-c34362f7423a",
   "situation": "inventaire",
   "donnees": {"idContenu": "6"},
-  "evaluation": "1",
+  "evaluation_id": "1",
 }
 ```
 

--- a/app/controllers/api/evaluations_controller.rb
+++ b/app/controllers/api/evaluations_controller.rb
@@ -18,10 +18,7 @@ module Api
     def show
       evaluation = Evaluation.find(params[:id])
 
-      questions = evaluation.campagne.questionnaire
-                    &.questionnaires_questions
-                    &.joins(:question)
-                    &.map(&:question) || []
+      questions = evaluation.campagne.questionnaire&.questions || []
 
       render json: { questions: questions }
     end

--- a/app/controllers/api/evaluations_controller.rb
+++ b/app/controllers/api/evaluations_controller.rb
@@ -2,6 +2,10 @@
 
 module Api
   class EvaluationsController < ActionController::API
+    rescue_from ActiveRecord::RecordNotFound do
+      render status: :not_found
+    end
+
     def create
       evaluation = Evaluation.new(EvaluationParams.from(params))
       if evaluation.save
@@ -9,6 +13,17 @@ module Api
       else
         render json: evaluation.errors, status: 422
       end
+    end
+
+    def show
+      evaluation = Evaluation.find(params[:id])
+
+      questions = evaluation.campagne.questionnaire
+                    &.questionnaires_questions
+                    &.joins(:question)
+                    &.map(&:question) || []
+
+      render json: { questions: questions }
     end
   end
 end

--- a/app/models/choix.rb
+++ b/app/models/choix.rb
@@ -5,4 +5,8 @@ class Choix < ApplicationRecord
   enum type_choix: %i[bon mauvais abstention]
 
   acts_as_list scope: :question_id
+
+  def as_json(_options = nil)
+    slice(:id, :intitule)
+  end
 end

--- a/app/models/question_qcm.rb
+++ b/app/models/question_qcm.rb
@@ -4,4 +4,10 @@ class QuestionQcm < Question
   has_many :choix, -> { order(position: :asc) }, foreign_key: :question_id
 
   accepts_nested_attributes_for :choix, allow_destroy: true
+
+  def as_json(_options = nil)
+    json = slice(:id, :intitule, :description, :choix)
+    json['type'] = 'qcm'
+    json
+  end
 end

--- a/app/models/question_redaction_note.rb
+++ b/app/models/question_redaction_note.rb
@@ -1,4 +1,9 @@
 # frozen_string_literal: true
 
 class QuestionRedactionNote < Question
+  def as_json(_options = nil)
+    json = slice(:id, :intitule, :entete_reponse, :expediteur, :message, :objet_reponse)
+    json['type'] = 'redaction_note'
+    json
+  end
 end

--- a/app/models/questionnaire.rb
+++ b/app/models/questionnaire.rb
@@ -2,6 +2,7 @@
 
 class Questionnaire < ApplicationRecord
   has_many :questionnaires_questions, -> { order(position: :asc) }, dependent: :destroy
+  has_many :questions, through: :questionnaires_questions
 
   validates :libelle, presence: true
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,8 +1,9 @@
 Rails.application.routes.draw do
   devise_for :administrateurs, ActiveAdmin::Devise.config
   ActiveAdmin.routes(self)
+
   namespace :api do
-    resources :evaluations, only: [:create]
+    resources :evaluations, only: [:create, :show]
     resources :evenements
   end
 end

--- a/spec/factories/questionnaire.rb
+++ b/spec/factories/questionnaire.rb
@@ -3,15 +3,5 @@
 FactoryBot.define do
   factory :questionnaire do
     libelle { 'Mon Questionnaire' }
-
-    transient do
-      questions { [] }
-    end
-
-    after(:create) do |questionnaire, evaluator|
-      questionnaire.questionnaires_questions = evaluator.questions.map do |question|
-        QuestionnaireQuestion.new(question: question)
-      end
-    end
   end
 end

--- a/spec/factories/questionnaire.rb
+++ b/spec/factories/questionnaire.rb
@@ -3,5 +3,15 @@
 FactoryBot.define do
   factory :questionnaire do
     libelle { 'Mon Questionnaire' }
+
+    transient do
+      questions { [] }
+    end
+
+    after(:create) do |questionnaire, evaluator|
+      questionnaire.questionnaires_questions = evaluator.questions.map do |question|
+        QuestionnaireQuestion.new(question: question)
+      end
+    end
   end
 end

--- a/spec/models/choix_spec.rb
+++ b/spec/models/choix_spec.rb
@@ -9,4 +9,11 @@ RSpec.describe Choix, type: :model do
     should define_enum_for(:type_choix)
       .with_values(%i[bon mauvais abstention])
   end
+
+  describe '#as_json' do
+    it 'serialise les champs' do
+      json = subject.as_json
+      expect(json.keys).to match_array(%w[id intitule])
+    end
+  end
 end

--- a/spec/models/question_qcm_spec.rb
+++ b/spec/models/question_qcm_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe QuestionQcm, type: :model do
+  it { should have_many(:choix).order(position: :asc).with_foreign_key(:question_id) }
+
+  describe '#as_json' do
+    it 'serialise les champs' do
+      json = subject.as_json
+      expect(json.keys).to match_array(%w[choix description id intitule type])
+      expect(json['type']).to eql('qcm')
+    end
+  end
+end

--- a/spec/models/question_redaction_note_spec.rb
+++ b/spec/models/question_redaction_note_spec.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe QuestionRedactionNote, type: :model do
+  describe '#as_json' do
+    it 'serialise les champs' do
+      json = subject.as_json
+      expect(json.keys).to match_array(%w[entete_reponse expediteur id intitule
+                                          message objet_reponse type])
+      expect(json['type']).to eql('redaction_note')
+    end
+  end
+end

--- a/spec/requests/evaluations_spec.rb
+++ b/spec/requests/evaluations_spec.rb
@@ -23,4 +23,32 @@ describe 'Evaluation API', type: :request do
       end
     end
   end
+
+  describe 'GET /evaluations/:id' do
+    let(:question) { create :question_qcm, intitule: 'Ma question' }
+    let(:questionnaire) { create :questionnaire, questions: [question] }
+    let(:campagne) { create :campagne, questionnaire: questionnaire }
+    let(:evaluation) { create :evaluation, campagne: campagne }
+
+    it 'retourne les questions de la campagne' do
+      get "/api/evaluations/#{evaluation.id}"
+
+      expect(response).to be_ok
+      expect(JSON.parse(response.body)['questions'].size).to eql(1)
+    end
+
+    it "retourne des questions vide lorsque qu'il n'y a pas de questionnaire" do
+      campagne.update(questionnaire: nil)
+      get "/api/evaluations/#{evaluation.id}"
+
+      expect(response).to be_ok
+      expect(JSON.parse(response.body)['questions'].size).to eql(0)
+    end
+
+    it "retourne une 404 lorsqu'elle n'existe pas" do
+      get '/api/evaluations/404'
+
+      expect(response).to have_http_status(404)
+    end
+  end
 end


### PR DESCRIPTION
Il est désormais possible de récupérer des informations sur l'évaluation. Spécifiquement si il y a un questionnaire associé a la campagne, elles sont retournées.