### PR TITLE
retourne une 404 si la campagne n'est pas trouvée

### DIFF
--- a/app/controllers/api/evaluations_controller.rb
+++ b/app/controllers/api/evaluations_controller.rb
@@ -4,11 +4,10 @@ module Api
   class EvaluationsController < ActionController::API
     def create
       evaluation = Evaluation.new(EvaluationParams.from(params))
-
       if evaluation.save
         render json: evaluation, status: :created
       else
-        render json: evaluation.errors.full_messages, status: 422
+        render json: evaluation.errors, status: 422
       end
     end
   end

--- a/app/controllers/api/evenements_controller.rb
+++ b/app/controllers/api/evenements_controller.rb
@@ -4,7 +4,6 @@ module Api
   class EvenementsController < ActionController::API
     def create
       @evenement = Evenement.new(evenement_params)
-
       if @evenement.save
         render json: @evenement, status: :created
       else

--- a/app/params/evaluation_params.rb
+++ b/app/params/evaluation_params.rb
@@ -16,7 +16,6 @@ class EvaluationParams
     def relie_campagne!(params)
       code_campagne = params.delete('code_campagne')
       campagne = Campagne.find_by code: code_campagne
-      campagne ||= Campagne.first
       params['campagne'] = campagne
     end
   end

--- a/config/locales/models/evaluation.yml
+++ b/config/locales/models/evaluation.yml
@@ -1,5 +1,13 @@
 fr:
   activerecord:
+    errors:
+      models:
+        evaluation:
+          attributes:
+            nom:
+              blank: doit être rempli
+            campagne:
+              required: code inexistant
     models:
       evaluation:
         one: Évaluation

--- a/spec/requests/evaluations_spec.rb
+++ b/spec/requests/evaluations_spec.rb
@@ -4,39 +4,21 @@ require 'rails_helper'
 
 describe 'Evaluation API', type: :request do
   describe 'POST /evaluations' do
-    let!(:campagne) { create :campagne }
+    let!(:campagne_ete19) { create :campagne, code: 'ETE19' }
 
     context 'Quand une requête est valide' do
-      context 'sans code campagne' do
-        let(:payload_valide) { { nom: 'Roger' } }
-
-        it 'Crée une évaluation avec la première campagne' do
-          expect { post '/api/evaluations', params: payload_valide }
-            .to change { Evaluation.count }.by(1)
-          expect(Evaluation.last.campagne).to eq campagne
-        end
-
-        it 'retourne une 201' do
-          post '/api/evaluations', params: payload_valide
-          expect(response).to have_http_status(201)
-        end
-      end
-
-      context 'avec code campagne' do
-        let!(:campagne_ete19) { create :campagne, code: 'ETE19' }
-        let(:paylod_valide_avec_campagne) { { nom: 'Roger', code_campagne: 'ETE19' } }
-        before { post '/api/evaluations', params: paylod_valide_avec_campagne }
-        it { expect(Evaluation.last.campagne).to eq campagne_ete19 }
-      end
+      let(:payload_valide_avec_campagne) { { nom: 'Roger', code_campagne: 'ETE19' } }
+      before { post '/api/evaluations', params: payload_valide_avec_campagne }
+      it { expect(Evaluation.last.campagne).to eq campagne_ete19 }
     end
 
     context 'Quand une requête est invalide' do
-      let(:payload_invalide) { { nom: '' } }
-
+      let(:payload_invalide) { { nom: '', code_campagne: 'ETE190' } }
       before { post '/api/evaluations', params: payload_invalide }
 
       it 'retourne une 422' do
-        expect(response.body).to eq '["Nom doit être rempli(e)"]'
+        json = JSON.parse(response.body)
+        expect(json.keys).to eq %w[nom campagne]
         expect(response).to have_http_status(422)
       end
     end


### PR DESCRIPTION
Renvoi une 404 si le code de la campagne n'existe pas, contribue à la #383 côté client.
Il faudrait afficher l'erreur côté client, je la laisse en draft tant que l'affichage côté client n'est pas fait, afin d'éviter de tt casser.