### PR TITLE
Ajoute l'illustration sur les questions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,7 @@ gem 'puma', '~> 4.0'
 gem 'activeadmin'
 gem 'activeadmin_addons'
 gem 'activeadmin_reorderable'
+gem 'activestorage-openstack'
 gem 'acts_as_list'
 gem 'bootsnap', '>= 1.1.0', require: false
 gem 'bootstrap', '~> 4.3', '>= 4.3.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -58,11 +58,16 @@ GEM
       actionpack (= 5.2.3)
       activerecord (= 5.2.3)
       marcel (~> 0.3.1)
-    activesupport (5.2.3)
+    activestorage-openstack (0.5.0)
       concurrent-ruby (~> 1.0, >= 1.0.2)
+      fog-openstack (~> 0.3)
       i18n (>= 0.7, < 2)
+      marcel
+      mime-types
       minitest (~> 5.1)
+      rails (~> 5.2.0)
       tzinfo (~> 1.1)
+    activesupport (5.2.3)
     acts_as_list (0.9.19)
       activerecord (>= 3.0)
     addressable (2.6.0)
@@ -112,6 +117,7 @@ GEM
       warden (~> 1.2.3)
     diff-lcs (1.3)
     erubi (1.8.0)
+    excon (0.64.0)
     execjs (2.7.0)
     factory_bot (5.0.2)
       activesupport (>= 4.2.0)
@@ -119,6 +125,18 @@ GEM
       factory_bot (~> 5.0.2)
       railties (>= 4.2.0)
     ffi (1.11.1)
+    fog-core (2.1.0)
+      builder
+      excon (~> 0.58)
+      formatador (~> 0.2)
+      mime-types
+    fog-json (1.2.0)
+      fog-core
+      multi_json (~> 1.10)
+    fog-openstack (0.3.10)
+      fog-core (>= 1.45, <= 2.1.0)
+      fog-json (>= 1.0)
+      ipaddress (>= 0.8)
     formatador (0.2.5)
     formtastic (3.1.5)
       actionpack (>= 3.2.13)
@@ -152,6 +170,7 @@ GEM
       has_scope (~> 0.6)
       railties (>= 5.0, < 6.0)
       responders (~> 2.0)
+    ipaddress (0.8.3)
     jaro_winkler (1.5.3)
     jquery-rails (4.3.5)
       rails-dom-testing (>= 1, < 3)
@@ -185,6 +204,9 @@ GEM
     marcel (0.3.3)
       mimemagic (~> 0.3.2)
     method_source (0.9.2)
+    mime-types (3.2.2)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2019.0331)
     mimemagic (0.3.3)
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)
@@ -192,6 +214,7 @@ GEM
       libv8 (>= 6.9.411)
     minitest (5.11.3)
     msgpack (1.3.0)
+    multi_json (1.13.1)
     nenv (0.3.0)
     nio4r (2.4.0)
     nokogiri (1.10.3)
@@ -349,6 +372,7 @@ DEPENDENCIES
   activeadmin
   activeadmin_addons
   activeadmin_reorderable
+  activestorage-openstack
   acts_as_list
   bootsnap (>= 1.1.0)
   bootstrap (~> 4.3, >= 4.3.1)

--- a/app/admin/question_redaction_note.rb
+++ b/app/admin/question_redaction_note.rb
@@ -3,13 +3,15 @@
 ActiveAdmin.register QuestionRedactionNote do
   menu parent: 'Questions'
 
-  permit_params :libelle, :intitule, :entete_reponse, :expediteur, :message, :objet_reponse
+  permit_params :libelle, :intitule, :illustration, :entete_reponse, :expediteur,
+                :message, :objet_reponse
 
   form do |f|
     f.semantic_errors
     f.inputs do
       f.input :libelle
       f.input :intitule
+      f.input :illustration, as: :file
       f.input :entete_reponse
       f.input :expediteur
       f.input :message

--- a/app/admin/questions_qcm.rb
+++ b/app/admin/questions_qcm.rb
@@ -3,7 +3,7 @@
 ActiveAdmin.register QuestionQcm do
   menu parent: 'Questions'
 
-  permit_params :libelle, :intitule, :description,
+  permit_params :libelle, :intitule, :description, :illustration,
                 choix_attributes: %i[id intitule type_choix _destroy]
 
   form do |f|
@@ -12,6 +12,7 @@ ActiveAdmin.register QuestionQcm do
       f.input :libelle
       f.input :intitule
       f.input :description
+      f.input :illustration, as: :file
       f.has_many :choix, allow_destroy: true do |c|
         c.input :id, as: :hidden
         c.input :intitule

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Question < ApplicationRecord
-  validates :intitule, presence: true
+  has_one_attached :illustration
 
   validates :intitule, presence: true
   validates :libelle, presence: true

--- a/app/models/question_qcm.rb
+++ b/app/models/question_qcm.rb
@@ -8,6 +8,9 @@ class QuestionQcm < Question
   def as_json(_options = nil)
     json = slice(:id, :intitule, :description, :choix)
     json['type'] = 'qcm'
+    if illustration.attached?
+      json['illustration'] = Rails.application.routes.url_helpers.url_for(illustration)
+    end
     json
   end
 end

--- a/app/models/question_redaction_note.rb
+++ b/app/models/question_redaction_note.rb
@@ -4,6 +4,9 @@ class QuestionRedactionNote < Question
   def as_json(_options = nil)
     json = slice(:id, :intitule, :entete_reponse, :expediteur, :message, :objet_reponse)
     json['type'] = 'redaction_note'
+    if illustration.attached?
+      json['illustration'] = Rails.application.routes.url_helpers.url_for(illustration)
+    end
     json
   end
 end

--- a/app/views/admin/question_qcms/_show.html.arb
+++ b/app/views/admin/question_qcms/_show.html.arb
@@ -6,6 +6,9 @@ panel 'Détails de la question' do
     row :libelle
     row :intitule
     row :description
+    row :illustration do |question|
+      image_tag url_for(question.illustration) if question.illustration.attached?
+    end
     row :created_at
   end
 end

--- a/app/views/admin/question_redaction_notes/_show.html.arb
+++ b/app/views/admin/question_redaction_notes/_show.html.arb
@@ -5,6 +5,9 @@ panel 'Détails de la question' do
     row :id
     row :libelle
     row :intitule
+    row :illustration do |question|
+      image_tag url_for(question.illustration) if question.illustration.attached?
+    end
     row :entete_reponse
     row :expediteur
     row :message

--- a/config/application.rb
+++ b/config/application.rb
@@ -36,6 +36,10 @@ module CompetencesProServeur
     config.middleware.use ActionDispatch::Cookies
     config.middleware.use ActionDispatch::Session::CookieStore
 
+    Rails.application.routes.default_url_options = {
+      host: ENV['HOST_URL']
+    }
+
     config.middleware.insert_before 0, Rack::Cors do
       allow do
         origins '*'

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -30,7 +30,7 @@ Rails.application.configure do
   # config.action_dispatch.x_sendfile_header = 'X-Accel-Redirect' # for NGINX
 
   # Store uploaded files on the local file system (see config/storage.yml for options)
-  config.active_storage.service = :local
+  config.active_storage.service = :openstack
 
   # Mount Action Cable outside main process or domain
   # config.action_cable.mount_path = nil

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -12,6 +12,10 @@ Rails.application.configure do
   # preloads Rails for running tests, you may have to set it to true.
   config.eager_load = false
 
+  Rails.application.routes.default_url_options = {
+    host: 'test'
+  }
+
   # Configure public file server for tests with Cache-Control for performance.
   config.public_file_server.enabled = true
   config.public_file_server.headers = {

--- a/config/storage.yml
+++ b/config/storage.yml
@@ -6,6 +6,18 @@ local:
   service: Disk
   root: <%= Rails.root.join("storage") %>
 
+openstack:
+  service: OpenStack
+  container: <%= ENV.fetch('OPENSTACK_CONTAINER', '') %>
+  credentials:
+    openstack_auth_url: <%= ENV.fetch('OPENSTACK_CONTAINER', '') %>
+    openstack_username: <%= ENV.fetch('OPENSTACK_USERNAME', '') %>
+    openstack_api_key: <%= ENV.fetch('OPENSTACK_API_KEY', '') %>
+    openstack_region: <%= ENV.fetch('OPENSTACK_REGION', '') %>
+    openstack_temp_url_key: <%= ENV.fetch('OPENSTACK_TEMP_URL_KEY', '') %>
+  connection_options:
+    chunk_size: 2097152 # 2MBs - 1MB is the default
+
 # Use rails credentials:edit to set the AWS secrets (as aws:access_key_id|secret_access_key)
 # amazon:
 #   service: S3

--- a/db/migrate/20190722072744_create_active_storage_tables.active_storage.rb
+++ b/db/migrate/20190722072744_create_active_storage_tables.active_storage.rb
@@ -1,0 +1,27 @@
+# This migration comes from active_storage (originally 20170806125915)
+class CreateActiveStorageTables < ActiveRecord::Migration[5.2]
+  def change
+    create_table :active_storage_blobs do |t|
+      t.string   :key,        null: false
+      t.string   :filename,   null: false
+      t.string   :content_type
+      t.text     :metadata
+      t.bigint   :byte_size,  null: false
+      t.string   :checksum,   null: false
+      t.datetime :created_at, null: false
+
+      t.index [ :key ], unique: true
+    end
+
+    create_table :active_storage_attachments do |t|
+      t.string     :name,     null: false
+      t.references :record,   null: false, polymorphic: true, index: false
+      t.references :blob,     null: false
+
+      t.datetime :created_at, null: false
+
+      t.index [ :record_type, :record_id, :name, :blob_id ], name: "index_active_storage_attachments_uniqueness", unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -29,6 +29,27 @@ ActiveRecord::Schema.define(version: 2019_07_26_101023) do
     t.index ["resource_type", "resource_id"], name: "index_active_admin_comments_on_resource_type_and_resource_id"
   end
 
+  create_table "active_storage_attachments", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "record_type", null: false
+    t.bigint "record_id", null: false
+    t.bigint "blob_id", null: false
+    t.datetime "created_at", null: false
+    t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
+    t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
+  end
+
+  create_table "active_storage_blobs", force: :cascade do |t|
+    t.string "key", null: false
+    t.string "filename", null: false
+    t.string "content_type"
+    t.text "metadata"
+    t.bigint "byte_size", null: false
+    t.string "checksum", null: false
+    t.datetime "created_at", null: false
+    t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
+  end
+
   create_table "administrateurs", force: :cascade do |t|
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
@@ -125,6 +146,7 @@ ActiveRecord::Schema.define(version: 2019_07_26_101023) do
     t.index ["situation_id"], name: "index_situations_configurations_on_situation_id"
   end
 
+  add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "campagnes", "questionnaires"
   add_foreign_key "choix", "questions"
   add_foreign_key "evaluations", "campagnes"

--- a/spec/models/question_qcm_spec.rb
+++ b/spec/models/question_qcm_spec.rb
@@ -6,10 +6,18 @@ RSpec.describe QuestionQcm, type: :model do
   it { should have_many(:choix).order(position: :asc).with_foreign_key(:question_id) }
 
   describe '#as_json' do
+    let(:file) { StringIO.new('test') }
+
     it 'serialise les champs' do
       json = subject.as_json
       expect(json.keys).to match_array(%w[choix description id intitule type])
       expect(json['type']).to eql('qcm')
+    end
+
+    it "serialise l'illustration" do
+      subject.illustration.attach(io: file, filename: 'test.png')
+      json = subject.as_json
+      expect(json.keys).to include('illustration')
     end
   end
 end

--- a/spec/models/question_redaction_note_spec.rb
+++ b/spec/models/question_redaction_note_spec.rb
@@ -4,11 +4,19 @@ require 'rails_helper'
 
 RSpec.describe QuestionRedactionNote, type: :model do
   describe '#as_json' do
+    let(:file) { StringIO.new('test') }
+
     it 'serialise les champs' do
       json = subject.as_json
       expect(json.keys).to match_array(%w[entete_reponse expediteur id intitule
                                           message objet_reponse type])
       expect(json['type']).to eql('redaction_note')
+    end
+
+    it "serialise l'illustration" do
+      subject.illustration.attach(io: file, filename: 'test.png')
+      json = subject.as_json
+      expect(json.keys).to include('illustration')
     end
   end
 end

--- a/spec/models/question_spec.rb
+++ b/spec/models/question_spec.rb
@@ -3,5 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe Question, type: :model do
-  it { should validate_presence_of :intitule }
+  it { is_expected.to validate_presence_of :intitule }
+
+  it { is_expected.to have_one(:illustration_attachment) }
 end


### PR DESCRIPTION
L'iillustration est rajouté dans les questions. Les fichiers d'illustrations sont stocké avec activestorage. 

Pour la prod, je prévoit d'utiliser l'object storage d'ovh, ce qui rajoute la dépendance `activestorage-openstack`.

Pour que l'api fonctionne il faut penser a setter la variable `HOST_URL`, PR a venir coté orchestrateur.

![Screenshot_2019-07-26 Combien y a t-il de bouteilles de O'cola au total Compétences Pro Serveur](https://user-images.githubusercontent.com/86659/61942528-e5192c00-af99-11e9-9628-f3253db4d22b.png)
