### PR TITLE
renvoie la liste des situations de la campagne dans le endpoint 

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,13 @@ L'api est accessible au point `/api`
       description: 'Ma description',
       choix: []
     }
+  ],
+  "situations": [
+    {
+      "id": 1,
+      "libelle": "Tri",
+      "nom_technique": "tri"
+    }
   ]
 }
 ```

--- a/app/controllers/api/evaluations_controller.rb
+++ b/app/controllers/api/evaluations_controller.rb
@@ -18,9 +18,10 @@ module Api
     def show
       evaluation = Evaluation.find(params[:id])
 
+      situations = evaluation.campagne.situations
       questions = evaluation.campagne.questionnaire&.questions || []
 
-      render json: { questions: questions }
+      render json: { questions: questions, situations: situations }
     end
   end
 end

--- a/app/models/campagne.rb
+++ b/app/models/campagne.rb
@@ -3,6 +3,7 @@
 class Campagne < ApplicationRecord
   has_many :evaluations
   has_many :situations_configurations, -> { order(position: :asc) }
+  has_many :situations, through: :situations_configurations
   belongs_to :questionnaire, optional: true
 
   validates :libelle, presence: true

--- a/app/models/situation.rb
+++ b/app/models/situation.rb
@@ -7,4 +7,8 @@ class Situation < ApplicationRecord
   def display_name
     libelle
   end
+
+  def as_json(_options = nil)
+    slice(:id, :libelle, :nom_technique)
+  end
 end

--- a/spec/requests/evaluations_spec.rb
+++ b/spec/requests/evaluations_spec.rb
@@ -50,5 +50,13 @@ describe 'Evaluation API', type: :request do
 
       expect(response).to have_http_status(404)
     end
+
+    it 'retourne les situations de la campagne' do
+      situation_inventaire = create :situation_inventaire, libelle: 'Inventaire'
+      campagne.situations << situation_inventaire
+      get "/api/evaluations/#{evaluation.id}"
+      expect(JSON.parse(response.body)['situations'].size).to eql(1)
+      expect(JSON.parse(response.body)['situations'][0]['libelle']).to eql('Inventaire')
+    end
   end
 end


### PR DESCRIPTION
Endpoint `api/evaluations/:id`
fix #118 

Exemple de retour d'API :

```json
{
  "questions": [
    {
      "id": 1,
      "intitule": "Mon QCM",
      "description": "T'en penses quoi ?",
      "choix": [
        {
        "id": 1,
        "intitule": "c'est tout pourri"
        },
        {
        "id": 2,
        "intitule": "c'est génial"
        },
        {
        "id": 3,
        "intitule": "j'ai arrêté de penser il y a bien longtemps"
        }
      ],
      "type": "qcm"
    },
    {
      "id": 2,
      "intitule": "Accident Germaine",
      "entete_reponse": "entête",
      "expediteur": "jean@bon.com",
      "message": "mon message",
      "objet_reponse": "t'en penses quoi ?",
      "type": "redaction_note"
    }
  ],
  "situations": [
    {
      "id": 2,
      "libelle": "Contrôle",
      "nom_technique": "controle"
    },
    {
      "id": 1,
      "libelle": "Tri",
      "nom_technique": "tri"
    }
  ]
}

```