### PR TITLE
Ajoute un libellé sur les questions.

### DIFF
--- a/app/admin/question_redaction_note.rb
+++ b/app/admin/question_redaction_note.rb
@@ -3,11 +3,12 @@
 ActiveAdmin.register QuestionRedactionNote do
   menu parent: 'Questions'
 
-  permit_params :intitule, :entete_reponse, :expediteur, :message, :objet_reponse
+  permit_params :libelle, :intitule, :entete_reponse, :expediteur, :message, :objet_reponse
 
   form do |f|
     f.semantic_errors
     f.inputs do
+      f.input :libelle
       f.input :intitule
       f.input :entete_reponse
       f.input :expediteur
@@ -20,6 +21,7 @@ ActiveAdmin.register QuestionRedactionNote do
   index do
     selectable_column
     column :id
+    column :libelle
     column :intitule
     column :entete_reponse
     column :expediteur

--- a/app/admin/questions_qcm.rb
+++ b/app/admin/questions_qcm.rb
@@ -3,11 +3,13 @@
 ActiveAdmin.register QuestionQcm do
   menu parent: 'Questions'
 
-  permit_params :intitule, :description, choix_attributes: %i[id intitule type_choix _destroy]
+  permit_params :libelle, :intitule, :description,
+                choix_attributes: %i[id intitule type_choix _destroy]
 
   form do |f|
     f.semantic_errors
     f.inputs do
+      f.input :libelle
       f.input :intitule
       f.input :description
       f.has_many :choix, allow_destroy: true do |c|
@@ -22,6 +24,7 @@ ActiveAdmin.register QuestionQcm do
   index do
     selectable_column
     column :id
+    column :libelle
     column :intitule
     column :description
     column :created_at

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -4,8 +4,9 @@ class Question < ApplicationRecord
   validates :intitule, presence: true
 
   validates :intitule, presence: true
+  validates :libelle, presence: true
 
   def display_name
-    intitule
+    libelle
   end
 end

--- a/app/views/admin/question_qcms/_show.html.arb
+++ b/app/views/admin/question_qcms/_show.html.arb
@@ -3,6 +3,7 @@
 panel 'Détails de la question' do
   attributes_table_for question_qcm do
     row :id
+    row :libelle
     row :intitule
     row :description
     row :created_at

--- a/app/views/admin/question_redaction_notes/_show.html.arb
+++ b/app/views/admin/question_redaction_notes/_show.html.arb
@@ -3,6 +3,7 @@
 panel 'Détails de la question' do
   attributes_table_for question_redaction_note do
     row :id
+    row :libelle
     row :intitule
     row :entete_reponse
     row :expediteur

--- a/config/locales/models/question.yml
+++ b/config/locales/models/question.yml
@@ -12,6 +12,7 @@ fr:
         created_at: Créée le
         updated_at: Mise à jour le
         intitule: Intitulé
+        libelle: Libellé
       question_redaction_note:
         entete_reponse: Entête réponse
         expediteur: Expéditeur

--- a/db/migrate/20190726101023_ajoute_libelle_aux_questions.rb
+++ b/db/migrate/20190726101023_ajoute_libelle_aux_questions.rb
@@ -1,0 +1,5 @@
+class AjouteLibelleAuxQuestions < ActiveRecord::Migration[5.2]
+  def change
+    add_column :questions, :libelle, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_07_19_092350) do
+ActiveRecord::Schema.define(version: 2019_07_26_101023) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -105,6 +105,7 @@ ActiveRecord::Schema.define(version: 2019_07_19_092350) do
     t.string "expediteur"
     t.string "message"
     t.string "objet_reponse"
+    t.string "libelle"
   end
 
   create_table "situations", force: :cascade do |t|

--- a/spec/factories/question.rb
+++ b/spec/factories/question.rb
@@ -2,9 +2,11 @@
 
 FactoryBot.define do
   factory :question do
+    libelle { 'Question' }
     intitule { 'Ma Question' }
   end
 
   factory :question_qcm do
+    libelle { 'Question' }
   end
 end

--- a/spec/features/question_qcm_spec.rb
+++ b/spec/features/question_qcm_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 describe 'Admin - Question QCM', type: :feature do
   before { se_connecter_comme_administrateur }
-  let!(:question) { create :question_qcm, intitule: 'Comment ça va ?' }
+  let!(:question) { create :question_qcm, libelle: 'question', intitule: 'Comment ça va ?' }
 
   describe 'index' do
     before { visit admin_question_qcms_path }
@@ -16,6 +16,7 @@ describe 'Admin - Question QCM', type: :feature do
   describe 'création' do
     before do
       visit new_admin_question_qcm_path
+      fill_in :question_qcm_libelle, with: 'question'
       fill_in :question_qcm_intitule, with: '2 + 2 = ?'
     end
 


### PR DESCRIPTION
Pour permettre une restitution des questions, nous avons besoin d'avoir un nom plus court qui correspond plus a ce que l'on veut tester. J'ai donc rajouté un libellé qui ne sera utilisé que pour cela.