### PR TITLE
Questions: affiche la restitution dans le rapport global

### DIFF
--- a/app/assets/stylesheets/restitution_globale.scss
+++ b/app/assets/stylesheets/restitution_globale.scss
@@ -2,6 +2,7 @@ $couleur-separateur: #afc5d0;
 $couleur-inventaire: #39c4d4;
 $couleur-controle: #e3b055;
 $couleur-tri: #9b7cd1;
+$couleur-questions: #398ad4;
 $couleur-fond-principale: #d8e8f7;
 $couleur-texte: #001c36;
 
@@ -123,5 +124,9 @@ $border-radius: .75rem;
 
   .tri {
     @include applique-theme($couleur-tri);
+  }
+
+  .questions {
+    @include applique-theme($couleur-questions);
   }
 }

--- a/app/models/fabrique_restitution.rb
+++ b/app/models/fabrique_restitution.rb
@@ -2,7 +2,7 @@
 
 class FabriqueRestitution
   class << self
-    def instancie(situation, evenements)
+    def instancie(situation, campagne, evenements)
       classe_restitution = {
         'inventaire' => Restitution::Inventaire,
         'controle' => Restitution::Controle,
@@ -10,13 +10,14 @@ class FabriqueRestitution
         'questions' => Restitution::Questions
       }
 
-      classe_restitution[situation.nom_technique].new(evenements)
+      classe_restitution[situation.nom_technique].new(campagne, evenements)
     end
 
     def depuis_evenement_id(id)
       evenement = Evenement.find id
+      campagne = evenement.evaluation.campagne
       evenements = Evenement.where(session_id: evenement.session_id).order(:date)
-      instancie evenement.situation, evenements
+      instancie evenement.situation, campagne, evenements
     end
   end
 end

--- a/app/models/restitution/base.rb
+++ b/app/models/restitution/base.rb
@@ -14,10 +14,11 @@ module Restitution
       ::Competence::NIVEAU_1 => 25
     }.freeze
 
-    attr_reader :evenements
+    attr_reader :campagne, :evenements
     delegate :session_id, :situation, :date, to: :premier_evenement
 
-    def initialize(evenements)
+    def initialize(campagne, evenements)
+      @campagne = campagne
       @evenements = evenements
     end
 

--- a/app/models/restitution/controle.rb
+++ b/app/models/restitution/controle.rb
@@ -47,7 +47,7 @@ module Restitution
       nouveaux_evenements = evenements.reject do |evenement|
         noms_evenements_pieces.include?(evenement.nom) && (compteur += 1) <= nombre
       end
-      self.class.new(nouveaux_evenements)
+      self.class.new(campagne, nouveaux_evenements)
     end
 
     def competences

--- a/app/models/restitution/globale.rb
+++ b/app/models/restitution/globale.rb
@@ -23,7 +23,7 @@ module Restitution
       return 0 if restitutions.blank?
 
       efficiences = restitutions.collect(&:efficience).compact
-      return NIVEAU_INDETERMINE if efficiences.include?(NIVEAU_INDETERMINE)
+      return NIVEAU_INDETERMINE if efficiences.include?(NIVEAU_INDETERMINE) || efficiences.blank?
 
       efficiences.inject(0.0) { |somme, efficience| somme + efficience } / efficiences.size
     end

--- a/app/models/restitution/inventaire.rb
+++ b/app/models/restitution/inventaire.rb
@@ -8,8 +8,8 @@ module Restitution
     }.freeze
 
     class Essai < Inventaire
-      def initialize(evenements, date_depart_situation)
-        super(evenements)
+      def initialize(campagne, evenements, date_depart_situation)
+        super(campagne, evenements)
         @date_depart_situation = date_depart_situation
       end
 
@@ -73,7 +73,7 @@ module Restitution
       end
       date_depart = evenements.first.date
       evenements_par_essais.map do |evenements|
-        Essai.new(evenements, date_depart)
+        Essai.new(campagne, evenements, date_depart)
       end
     end
 

--- a/app/models/restitution/questions.rb
+++ b/app/models/restitution/questions.rb
@@ -7,7 +7,7 @@ module Restitution
     }.freeze
 
     def termine?
-      reponses.size == 2
+      reponses.size == campagne.questionnaire.questionnaires_questions.size
     end
 
     def reponses

--- a/app/models/restitution/questions.rb
+++ b/app/models/restitution/questions.rb
@@ -24,6 +24,10 @@ module Restitution
       evenements.find_all { |e| e.nom == EVENEMENT[:REPONSE] }
     end
 
+    def efficience
+      nil
+    end
+
     private
 
     def questions

--- a/app/models/restitution/questions.rb
+++ b/app/models/restitution/questions.rb
@@ -7,11 +7,38 @@ module Restitution
     }.freeze
 
     def termine?
-      reponses.size == campagne.questionnaire.questionnaires_questions.size
+      reponses.size == questions.size
+    end
+
+    def questions_et_reponses
+      questions_repondues
+        .map do |question|
+        {
+          question: question,
+          reponse: trouve_reponse(question.id)
+        }
+      end
     end
 
     def reponses
       evenements.find_all { |e| e.nom == EVENEMENT[:REPONSE] }
+    end
+
+    private
+
+    def questions
+      campagne.questionnaire.questions
+    end
+
+    def questions_repondues
+      questions_ids = reponses.collect { |r| r.donnees['question'] }
+      questions.where(id: questions_ids)
+    end
+
+    def trouve_reponse(question_id)
+      reponses.find do |evenement|
+        evenement.donnees['question'] == question_id
+      end.donnees['reponse']
     end
   end
 end

--- a/app/views/admin/campagnes/_show.html.arb
+++ b/app/views/admin/campagnes/_show.html.arb
@@ -19,7 +19,8 @@ end
 panel 'Évaluations' do
   table_for campagne.evaluations do
     column :nom do |evaluation|
-      auto_link(evaluation)
+      link_to evaluation.nom,
+              admin_restitutions_path(evaluation_id: evaluation.id)
     end
     column :created_at
   end

--- a/app/views/admin/restitution_globale/_questions.html.arb
+++ b/app/views/admin/restitution_globale/_questions.html.arb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+div class: 'row questions' do
+  restitution.questions_et_reponses.each do |question_et_reponse|
+    div class: 'col-4 px-5 mb-4' do
+      div question_et_reponse[:question].libelle
+      if question_et_reponse[:question].is_a?(QuestionQcm)
+        div class: 'btn-group my-2' do
+          ::Choix.type_choix.each do |nom, _valeur|
+            choix = question_et_reponse[:question].choix.find(question_et_reponse[:reponse])
+            active = nom == choix.type_choix ? 'active' : ''
+            button class: "btn #{active}" do
+              t(".#{nom}")
+            end
+          end
+        end
+      else
+        div simple_format(question_et_reponse[:reponse])
+      end
+    end
+  end
+end

--- a/app/views/admin/restitution_globale/_restitution_globale.html.arb
+++ b/app/views/admin/restitution_globale/_restitution_globale.html.arb
@@ -14,6 +14,8 @@ div class: :panel do
 
   div class: :row do
     restitution_globale.restitutions.each do |restitution|
+      next if restitution.efficience.nil?
+
       situation = restitution.situation
       div class: "#{rapport_colonne_class} #{situation.nom_technique}" do
         div t('.situation', situation: situation.libelle)
@@ -26,6 +28,7 @@ div class: :panel do
         end
       end
     end
+    nil
   end
 end
 

--- a/app/views/admin/restitutions/_restitution_questions.html.arb
+++ b/app/views/admin/restitutions/_restitution_questions.html.arb
@@ -1,12 +1,21 @@
 # frozen_string_literal: true
 
 panel t('.restitution_questions') do
-  table_for restitutions.reponses do
-    column t('.question') do |reponse|
-      reponse.donnees['question']
+  table_for restitutions.questions_et_reponses do
+    column t('.question') do |question_reponse|
+      auto_link(question_reponse[:question])
     end
-    column t('.reponse') do |reponse|
-      simple_format(reponse.donnees['reponse'])
+    column t('.reponse') do |question_reponse|
+      question = question_reponse[:question]
+      if question.is_a?(QuestionQcm)
+        question.choix.find(question_reponse[:reponse]).intitule
+      else
+        simple_format(question_reponse[:reponse])
+      end
+    end
+    column t('.correct') do |question_reponse|
+      question = question_reponse[:question]
+      question.choix.find(question_reponse[:reponse]).type_choix if question.is_a?(QuestionQcm)
     end
   end
 end

--- a/config/locales/views/restitutions.yml
+++ b/config/locales/views/restitutions.yml
@@ -12,6 +12,10 @@ fr:
       inventaire:
         <<: *commun
         nombre_essais: Nbre d'essais
+      questions:
+        abstention: Ne sait pas
+        bon: Correct
+        mauvais: Erreur
       tri:
         <<: *commun
         reste_plateau: Reste plateau

--- a/spec/models/restitution/base_spec.rb
+++ b/spec/models/restitution/base_spec.rb
@@ -3,7 +3,8 @@
 require 'rails_helper'
 
 describe Restitution::Base do
-  let(:restitution) { described_class.new(evenements) }
+  let(:campagne)    { build(:campagne) }
+  let(:restitution) { described_class.new(campagne, evenements) }
 
   context 'lorsque le dernier événement est stop' do
     let(:evenements) do
@@ -23,12 +24,12 @@ describe Restitution::Base do
       build(:evenement_rejoue_consigne),
       build(:evenement_rejoue_consigne)
     ]
-    expect(described_class.new(evenements).nombre_rejoue_consigne).to eql(2)
+    expect(described_class.new(campagne, evenements).nombre_rejoue_consigne).to eql(2)
   end
 
   it 'envoie une exception not implemented pour la méthode termine?' do
     expect do
-      described_class.new([]).termine?
+      described_class.new(campagne, []).termine?
     end.to raise_error(NotImplementedError)
   end
 
@@ -37,15 +38,15 @@ describe Restitution::Base do
     evenements = [
       build(:evenement_demarrage, evaluation: evaluation)
     ]
-    expect(described_class.new(evenements).evaluation).to eql(evaluation)
+    expect(described_class.new(campagne, evenements).evaluation).to eql(evaluation)
   end
 
   it 'renvoie par défaut une liste vide pour les compétences évaluées' do
-    expect(described_class.new([]).competences).to eql({})
+    expect(described_class.new(campagne, []).competences).to eql({})
   end
 
   describe '#efficience' do
-    let(:restitution) { described_class.new([]) }
+    let(:restitution) { described_class.new(campagne, []) }
 
     it "retourne l'efficience sans les compétences persévérance et compréhension consigne" do
       expect(restitution).to receive(:competences).and_return(

--- a/spec/models/restitution/controle_spec.rb
+++ b/spec/models/restitution/controle_spec.rb
@@ -3,7 +3,8 @@
 require 'rails_helper'
 
 describe Restitution::Controle do
-  let(:restitution) { described_class.new(evenements) }
+  let(:campagne) { build :campagne }
+  let(:restitution) { described_class.new(campagne, evenements) }
 
   context 'avec toutes les pieces enregistrées' do
     let(:evenements) do

--- a/spec/models/restitution/globale_spec.rb
+++ b/spec/models/restitution/globale_spec.rb
@@ -47,5 +47,23 @@ describe Restitution::Globale do
         expect(restitution_globale.efficience).to eq(::Restitution::Globale::NIVEAU_INDETERMINE)
       }
     end
+
+    context 'ignore les efficiences a nil' do
+      let(:restitutions) do
+        [double(efficience: 20), double(efficience: nil)]
+      end
+      it {
+        expect(restitution_globale.efficience).to eq(20)
+      }
+    end
+
+    context 'avec une seul efficience a nil, retourn indéterminée' do
+      let(:restitutions) do
+        [double(efficience: nil)]
+      end
+      it {
+        expect(restitution_globale.efficience).to eq(::Restitution::Globale::NIVEAU_INDETERMINE)
+      }
+    end
   end
 end

--- a/spec/models/restitution/inventaire_spec.rb
+++ b/spec/models/restitution/inventaire_spec.rb
@@ -3,13 +3,15 @@
 require 'rails_helper'
 
 describe Restitution::Inventaire do
+  let(:campagne) { build :campagne }
+
   describe Restitution::Inventaire::Essai do
     it 'retourne le temps depuis le début de la situation' do
       evenements = [
         build(:evenement_ouverture_contenant, date: 2.minute.ago),
         build(:evenement_ouverture_contenant, date: 1.minute.ago)
       ]
-      restitution = described_class.new(evenements, 5.minute.ago)
+      restitution = described_class.new(campagne, evenements, 5.minute.ago)
       expect(restitution.temps_total).to be_within(0.1).of(240)
     end
 
@@ -25,7 +27,7 @@ describe Restitution::Inventaire do
                   }
                 })
         ]
-        restitution = described_class.new(evenements, 5.minute.ago)
+        restitution = described_class.new(campagne, evenements, 5.minute.ago)
         expect(restitution.nombre_erreurs).to eql(0)
         expect(restitution.nombre_de_non_remplissage).to eql(0)
         expect(restitution.nombre_erreurs_sauf_de_non_remplissage).to eql(0)
@@ -42,7 +44,7 @@ describe Restitution::Inventaire do
                   }
                 })
         ]
-        restitution = described_class.new(evenements, 5.minute.ago)
+        restitution = described_class.new(campagne, evenements, 5.minute.ago)
         expect(restitution.nombre_erreurs).to eql(2)
         expect(restitution.nombre_de_non_remplissage).to eql(0)
         expect(restitution.nombre_erreurs_sauf_de_non_remplissage).to eql(2)
@@ -52,7 +54,7 @@ describe Restitution::Inventaire do
         evenements = [
           build(:evenement_ouverture_contenant)
         ]
-        restitution = described_class.new(evenements, 5.minute.ago)
+        restitution = described_class.new(campagne, evenements, 5.minute.ago)
         expect(restitution.nombre_erreurs).to be_nil
         expect(restitution.nombre_de_non_remplissage).to be_nil
         expect(restitution.nombre_erreurs_sauf_de_non_remplissage).to be_nil
@@ -69,7 +71,7 @@ describe Restitution::Inventaire do
                   }
                 })
         ]
-        restitution = described_class.new(evenements, 5.minute.ago)
+        restitution = described_class.new(campagne, evenements, 5.minute.ago)
         expect(restitution.nombre_erreurs).to eql(1)
         expect(restitution.nombre_de_non_remplissage).to eql(1)
         expect(restitution.nombre_erreurs_sauf_de_non_remplissage).to eql(0)
@@ -81,7 +83,7 @@ describe Restitution::Inventaire do
     evenements = [
       build(:evenement_demarrage, session_id: 'exemple')
     ]
-    restitution = described_class.new(evenements)
+    restitution = described_class.new(campagne, evenements)
     expect(restitution.session_id).to eql('exemple')
   end
 
@@ -90,7 +92,7 @@ describe Restitution::Inventaire do
       build(:evenement_demarrage),
       build(:evenement_saisie_inventaire, :ok)
     ]
-    restitution = described_class.new(evenements)
+    restitution = described_class.new(campagne, evenements)
     expect(restitution).to be_reussite
     expect(restitution).to be_termine
     expect(restitution).to_not be_abandon
@@ -102,7 +104,7 @@ describe Restitution::Inventaire do
       build(:evenement_demarrage),
       build(:evenement_saisie_inventaire, :echec)
     ]
-    restitution = described_class.new(evenements)
+    restitution = described_class.new(campagne, evenements)
     expect(restitution).to_not be_reussite
     expect(restitution).to_not be_abandon
     expect(restitution).to_not be_en_cours
@@ -113,7 +115,7 @@ describe Restitution::Inventaire do
       build(:evenement_demarrage),
       build(:evenement_stop)
     ]
-    restitution = described_class.new(evenements)
+    restitution = described_class.new(campagne, evenements)
     expect(restitution).to_not be_reussite
     expect(restitution).to be_abandon
     expect(restitution).to_not be_en_cours
@@ -123,7 +125,7 @@ describe Restitution::Inventaire do
     evenements = [
       build(:evenement_demarrage)
     ]
-    restitution = described_class.new(evenements)
+    restitution = described_class.new(campagne, evenements)
     expect(restitution).to_not be_reussite
     expect(restitution).to_not be_abandon
     expect(restitution).to be_en_cours
@@ -134,7 +136,7 @@ describe Restitution::Inventaire do
       build(:evenement_demarrage, date: 10.minutes.ago),
       build(:evenement_saisie_inventaire, :ok, date: 4.minutes.ago)
     ]
-    restitution = described_class.new(evenements)
+    restitution = described_class.new(campagne, evenements)
     expect(restitution.temps_total).to be_within(0.1).of(360)
   end
 
@@ -144,7 +146,7 @@ describe Restitution::Inventaire do
       build(:evenement_ouverture_contenant),
       build(:evenement_ouverture_contenant)
     ]
-    restitution = described_class.new(evenements)
+    restitution = described_class.new(campagne, evenements)
     expect(restitution.nombre_ouverture_contenant).to eql(3)
   end
 
@@ -155,7 +157,7 @@ describe Restitution::Inventaire do
       build(:evenement_saisie_inventaire, :echec),
       build(:evenement_saisie_inventaire, :ok)
     ]
-    restitution = described_class.new(evenements)
+    restitution = described_class.new(campagne, evenements)
     expect(restitution.nombre_essais_validation).to eql(4)
   end
 
@@ -169,7 +171,7 @@ describe Restitution::Inventaire do
         build(:evenement_saisie_inventaire, :echec, date: 7.minutes.ago),
         build(:evenement_saisie_inventaire, :ok, date: 5.minutes.ago)
       ]
-      restitution = described_class.new(evenements)
+      restitution = described_class.new(campagne, evenements)
       expect(restitution.essais_verifies.size).to eql(2)
       restitution.essais_verifies.first.tap do |essai|
         expect(essai).to_not be_reussite
@@ -192,7 +194,7 @@ describe Restitution::Inventaire do
         build(:evenement_saisie_inventaire, :echec, date: 5.minutes.ago),
         build(:evenement_ouverture_contenant, date: 4.minutes.ago)
       ]
-      restitution = described_class.new(evenements)
+      restitution = described_class.new(campagne, evenements)
       expect(restitution.essais_verifies.size).to eql(2)
     end
   end
@@ -207,7 +209,7 @@ describe Restitution::Inventaire do
         build(:evenement_saisie_inventaire, :echec, date: 5.minutes.ago),
         build(:evenement_ouverture_contenant, date: 4.minutes.ago)
       ]
-      restitution = described_class.new(evenements)
+      restitution = described_class.new(campagne, evenements)
       expect(restitution.essais.size).to eql(3)
     end
   end
@@ -217,7 +219,7 @@ describe Restitution::Inventaire do
       evenements = [
         build(:evenement_demarrage)
       ]
-      restitution = described_class.new(evenements)
+      restitution = described_class.new(campagne, evenements)
       expect(restitution.competences.keys).to eql([Competence::PERSEVERANCE,
                                                    Competence::COMPREHENSION_CONSIGNE,
                                                    Competence::RAPIDITE,

--- a/spec/models/restitution/questions_spec.rb
+++ b/spec/models/restitution/questions_spec.rb
@@ -3,7 +3,10 @@
 require 'rails_helper'
 
 describe Restitution::Questions do
-  let(:campagne) { build :campagne }
+  let(:question1) { build :question_qcm, intitule: 'Ma question 1' }
+  let(:question2) { build :question_qcm, intitule: 'Ma question 2' }
+  let(:questionnaire) { create :questionnaire, questions: [question1, question2] }
+  let(:campagne) { build :campagne, questionnaire: questionnaire }
 
   describe '#termine?' do
     it "lorsque aucune questions n'a encore été répondu" do
@@ -15,7 +18,7 @@ describe Restitution::Questions do
     it 'lorsque une des questions a été répondu' do
       evenements = [
         build(:evenement_demarrage),
-        build(:evenement_reponse, donnees: { question: :litteratie, reponse: 1 })
+        build(:evenement_reponse, donnees: { question: question1.id, reponse: 1 })
       ]
       restitution = described_class.new(campagne, evenements)
       expect(restitution).to_not be_termine
@@ -24,8 +27,8 @@ describe Restitution::Questions do
     it 'lorsque les 2 questions ont été répondu' do
       evenements = [
         build(:evenement_demarrage),
-        build(:evenement_reponse, donnees: { question: :litteratie, reponse: 1 }),
-        build(:evenement_reponse, donnees: { question: :numeratie, reponse: 2 })
+        build(:evenement_reponse, donnees: { question: question1.id, reponse: 1 }),
+        build(:evenement_reponse, donnees: { question: question2.id, reponse: 2 })
       ]
       restitution = described_class.new(campagne, evenements)
       expect(restitution).to be_termine

--- a/spec/models/restitution/questions_spec.rb
+++ b/spec/models/restitution/questions_spec.rb
@@ -3,10 +3,12 @@
 require 'rails_helper'
 
 describe Restitution::Questions do
+  let(:campagne) { build :campagne }
+
   describe '#termine?' do
     it "lorsque aucune questions n'a encore été répondu" do
       evenements = [build(:evenement_demarrage)]
-      restitution = described_class.new(evenements)
+      restitution = described_class.new(campagne, evenements)
       expect(restitution).to_not be_termine
     end
 
@@ -15,7 +17,7 @@ describe Restitution::Questions do
         build(:evenement_demarrage),
         build(:evenement_reponse, donnees: { question: :litteratie, reponse: 1 })
       ]
-      restitution = described_class.new(evenements)
+      restitution = described_class.new(campagne, evenements)
       expect(restitution).to_not be_termine
     end
 
@@ -25,7 +27,7 @@ describe Restitution::Questions do
         build(:evenement_reponse, donnees: { question: :litteratie, reponse: 1 }),
         build(:evenement_reponse, donnees: { question: :numeratie, reponse: 2 })
       ]
-      restitution = described_class.new(evenements)
+      restitution = described_class.new(campagne, evenements)
       expect(restitution).to be_termine
     end
   end
@@ -36,7 +38,7 @@ describe Restitution::Questions do
         build(:evenement_reponse),
         build(:evenement_reponse)
       ]
-      restitution = described_class.new(evenements)
+      restitution = described_class.new(campagne, evenements)
       expect(restitution.reponses.size).to eql(2)
     end
 
@@ -45,7 +47,7 @@ describe Restitution::Questions do
         build(:evenement_demarrage),
         build(:evenement_reponse)
       ]
-      restitution = described_class.new(evenements)
+      restitution = described_class.new(campagne, evenements)
       expect(restitution.reponses.size).to eql(1)
     end
   end

--- a/spec/models/restitution/questions_spec.rb
+++ b/spec/models/restitution/questions_spec.rb
@@ -80,4 +80,11 @@ describe Restitution::Questions do
       expect(restitution.reponses.size).to eql(1)
     end
   end
+
+  describe '#efficience' do
+    it 'retourne nil' do
+      restitution = described_class.new(campagne, [])
+      expect(restitution.efficience).to be_nil
+    end
+  end
 end

--- a/spec/models/restitution/questions_spec.rb
+++ b/spec/models/restitution/questions_spec.rb
@@ -3,8 +3,10 @@
 require 'rails_helper'
 
 describe Restitution::Questions do
-  let(:question1) { build :question_qcm, intitule: 'Ma question 1' }
-  let(:question2) { build :question_qcm, intitule: 'Ma question 2' }
+  let(:situation) { create :situation, libelle: 'Questions', nom_technique: 'questions' }
+  let(:evaluation) { create :evaluation, nom: 'Test' }
+  let(:question1) { create :question_qcm, intitule: 'Ma question 1' }
+  let(:question2) { create :question_qcm, intitule: 'Ma question 2' }
   let(:questionnaire) { create :questionnaire, questions: [question1, question2] }
   let(:campagne) { build :campagne, questionnaire: questionnaire }
 
@@ -32,6 +34,30 @@ describe Restitution::Questions do
       ]
       restitution = described_class.new(campagne, evenements)
       expect(restitution).to be_termine
+    end
+  end
+
+  describe '#questions_et_reponses' do
+    it "retourne aucune question et réponse si aucune n'a été répondu" do
+      evenements = [
+        build(:evenement_demarrage)
+      ]
+      restitution = described_class.new(campagne, evenements)
+      expect(restitution.questions_et_reponses.size).to eq(0)
+    end
+
+    it 'retourne les questions et les réponses du questionnaire' do
+      evenements = [
+        create(:evenement_demarrage, evaluation: evaluation, situation: situation),
+        create(:evenement_reponse,
+               evaluation: evaluation,
+               situation: situation,
+               donnees: { question: question1.id, reponse: 1 })
+      ]
+      restitution = described_class.new(campagne, evenements)
+      expect(restitution.questions_et_reponses.size).to eq(1)
+      expect(restitution.questions_et_reponses.first[:question]).to eql(question1)
+      expect(restitution.questions_et_reponses.first[:reponse]).to eql(1)
     end
   end
 

--- a/spec/models/restitution/tri_spec.rb
+++ b/spec/models/restitution/tri_spec.rb
@@ -3,7 +3,8 @@
 require 'rails_helper'
 
 describe Restitution::Tri do
-  let(:restitution) { described_class.new(evenements) }
+  let(:campagne) { build :campagne }
+  let(:restitution) { described_class.new(campagne, evenements) }
 
   context 'avec toutes les pieces enregistrées' do
     let(:evenements) do
@@ -58,7 +59,7 @@ describe Restitution::Tri do
       evenements = [
         build(:evenement_demarrage)
       ]
-      restitution = described_class.new(evenements)
+      restitution = described_class.new(campagne, evenements)
       expect(restitution.competences.keys).to eql([Competence::PERSEVERANCE,
                                                    Competence::COMPREHENSION_CONSIGNE,
                                                    Competence::RAPIDITE,


### PR DESCRIPTION
![Screenshot_2019-07-26 526c3940-197f-4304-bf8c-6373459f63d8 Compétences Pro Serveur](https://user-images.githubusercontent.com/86659/61952439-28809400-afb4-11e9-97e4-0316a17a7728.png)


![Screenshot_2019-07-26 Restitution Globale Compétences Pro Serveur](https://user-images.githubusercontent.com/86659/61952415-143c9700-afb4-11e9-89c6-efe77da3dd3d.png)

Fix #104 et #126 