### PR TITLE
lie une campagne à un compte et limite les accès pour un compte non administrateur

### DIFF
--- a/app/admin/campagnes.rb
+++ b/app/admin/campagnes.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 ActiveAdmin.register Campagne do
-  permit_params :libelle, :code, :questionnaire_id,
+  permit_params :libelle, :code, :questionnaire_id, :compte, :compte_id,
                 situations_configurations_attributes: %i[id situation_id _destroy]
 
   show do
@@ -11,6 +11,12 @@ ActiveAdmin.register Campagne do
   form do |f|
     f.semantic_errors
     f.inputs do
+      if current_compte.administrateur?
+        f.input :compte
+      else
+        f.object.compte_id ||= current_compte.id
+        f.input :compte_id, as: :hidden
+      end
       f.input :libelle
       f.input :code
       f.input :questionnaire

--- a/app/admin/campagnes.rb
+++ b/app/admin/campagnes.rb
@@ -4,6 +4,14 @@ ActiveAdmin.register Campagne do
   permit_params :libelle, :code, :questionnaire_id, :compte, :compte_id,
                 situations_configurations_attributes: %i[id situation_id _destroy]
 
+  index do
+    selectable_column
+    column :libelle
+    column :code
+    column :compte if can?(:manage, Compte)
+    actions
+  end
+
   show do
     render partial: 'show'
   end
@@ -11,12 +19,7 @@ ActiveAdmin.register Campagne do
   form do |f|
     f.semantic_errors
     f.inputs do
-      if current_compte.administrateur?
-        f.input :compte
-      else
-        f.object.compte_id ||= current_compte.id
-        f.input :compte_id, as: :hidden
-      end
+      f.input :compte if can?(:manage, Compte)
       f.input :libelle
       f.input :code
       f.input :questionnaire
@@ -26,5 +29,12 @@ ActiveAdmin.register Campagne do
       end
     end
     f.actions
+  end
+
+  controller do
+    def create
+      params[:campagne][:compte_id] ||= current_compte.id
+      create!
+    end
   end
 end

--- a/app/admin/evaluation.rb
+++ b/app/admin/evaluation.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
 ActiveAdmin.register Evaluation do
+  filter :campagne, collection: proc { evaluations_visibles(current_compte) }
+  filter :created_at
+
   index do
     column :nom
     column :campagne

--- a/app/admin/evaluation.rb
+++ b/app/admin/evaluation.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 ActiveAdmin.register Evaluation do
-  filter :campagne, collection: proc { evaluations_visibles(current_compte) }
+  filter :campagne, collection: proc { evaluations_visibles }
   filter :created_at
 
   index do
@@ -11,6 +11,16 @@ ActiveAdmin.register Evaluation do
     column '' do |evaluation|
       span link_to t('.restitution'),
                    admin_restitutions_path(evaluation_id: evaluation.id)
+    end
+  end
+
+  controller do
+    helper_method :evaluations_visibles
+
+    private
+
+    def evaluations_visibles
+      current_compte.administrateur? ? Campagne.all : Campagne.where(compte: current_compte)
     end
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -18,8 +18,4 @@ module ApplicationHelper
   def rapport_colonne_class
     'col-4 px-5 mb-4'
   end
-
-  def evaluations_visibles(compte)
-    compte.administrateur? ? Campagne.all : Campagne.where(compte: compte)
-  end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -18,4 +18,8 @@ module ApplicationHelper
   def rapport_colonne_class
     'col-4 px-5 mb-4'
   end
+
+  def evaluations_visibles(compte)
+    compte.administrateur? ? Campagne.all : Campagne.where(compte: compte)
+  end
 end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -4,13 +4,20 @@ class Ability
   include CanCan::Ability
 
   def initialize(compte)
-    droit_generiques
+    droits_generiques
+    droit_campagne compte
     cannot :manage, Compte unless compte.administrateur?
   end
 
   private
 
-  def droit_generiques
+  def droit_campagne(compte)
+    cannot :manage, Campagne unless compte.administrateur?
+    can :create, Campagne
+    can %i[update read destroy], Campagne, compte_id: compte.id
+  end
+
+  def droits_generiques
     can :manage, :all
     cannot %i[destroy create], Evaluation
     cannot %i[update create], Evenement

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -6,6 +6,8 @@ class Ability
   def initialize(compte)
     droits_generiques
     droit_campagne compte
+    droit_evaluation compte
+    droit_evenement compte
     cannot :manage, Compte unless compte.administrateur?
   end
 
@@ -15,6 +17,16 @@ class Ability
     cannot :manage, Campagne unless compte.administrateur?
     can :create, Campagne
     can %i[update read destroy], Campagne, compte_id: compte.id
+  end
+
+  def droit_evaluation(compte)
+    cannot :manage, Evaluation unless compte.administrateur?
+    can :manage, Evaluation, campagne: { compte_id: compte.id }
+  end
+
+  def droit_evenement(compte)
+    cannot :read, Evenement unless compte.administrateur?
+    can :read, Evenement, evaluation: { campagne: { compte_id: compte.id } }
   end
 
   def droits_generiques

--- a/app/models/campagne.rb
+++ b/app/models/campagne.rb
@@ -5,6 +5,7 @@ class Campagne < ApplicationRecord
   has_many :situations_configurations, -> { order(position: :asc) }
   has_many :situations, through: :situations_configurations
   belongs_to :questionnaire, optional: true
+  belongs_to :compte
 
   validates :libelle, presence: true
   validates :code, presence: true, uniqueness: true

--- a/app/models/compte.rb
+++ b/app/models/compte.rb
@@ -7,6 +7,10 @@ class Compte < ApplicationRecord
          :recoverable, :rememberable, :validatable
   validates :role, inclusion: { in: %w[administrateur organisation] }, presence: true
 
+  def display_name
+    email
+  end
+
   def administrateur?
     role == 'administrateur'
   end

--- a/app/views/admin/campagnes/_show.html.arb
+++ b/app/views/admin/campagnes/_show.html.arb
@@ -6,6 +6,7 @@ panel 'Détails de la campagne' do
     row :libelle
     row :code
     row :questionnaire
+    row :compte if can?(:manage, Compte)
     row :created_at
   end
 end

--- a/db/migrate/20190729084304_lie_une_campagne_a_un_compte.rb
+++ b/db/migrate/20190729084304_lie_une_campagne_a_un_compte.rb
@@ -1,0 +1,5 @@
+class LieUneCampagneAUnCompte < ActiveRecord::Migration[5.2]
+  def change
+    add_reference :campagnes, :compte, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_07_29_082541) do
+ActiveRecord::Schema.define(version: 2019_07_29_084304) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -56,6 +56,8 @@ ActiveRecord::Schema.define(version: 2019_07_29_082541) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "questionnaire_id"
+    t.bigint "compte_id"
+    t.index ["compte_id"], name: "index_campagnes_on_compte_id"
     t.index ["questionnaire_id"], name: "index_campagnes_on_questionnaire_id"
   end
 
@@ -148,6 +150,7 @@ ActiveRecord::Schema.define(version: 2019_07_29_082541) do
   end
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "campagnes", "comptes"
   add_foreign_key "campagnes", "questionnaires"
   add_foreign_key "choix", "questions"
   add_foreign_key "evaluations", "campagnes"

--- a/spec/factories/campagne.rb
+++ b/spec/factories/campagne.rb
@@ -4,5 +4,6 @@ FactoryBot.define do
   factory :campagne do
     libelle { 'Ma campagne' }
     code { '123DB' }
+    compte
   end
 end

--- a/spec/factories/compte.rb
+++ b/spec/factories/compte.rb
@@ -4,6 +4,7 @@ FactoryBot.define do
   factory :compte do
     email
     password { 'password' }
+    role { 'administrateur' }
   end
 
   sequence :email do |n|

--- a/spec/factories/compte.rb
+++ b/spec/factories/compte.rb
@@ -1,10 +1,14 @@
 # frozen_string_literal: true
 
 FactoryBot.define do
-  factory :compte do
+  factory :compte, aliases: [:compte_admin] do
     email
     password { 'password' }
     role { 'administrateur' }
+
+    factory :compte_organisation do
+      role { 'organisation' }
+    end
   end
 
   sequence :email do |n|

--- a/spec/features/campagne_spec.rb
+++ b/spec/features/campagne_spec.rb
@@ -3,11 +3,14 @@
 require 'rails_helper'
 
 describe 'Admin - Campagne', type: :feature do
-  before { se_connecter_comme_organisation }
+  let!(:compte_connecte) { se_connecter_comme_organisation }
   let!(:ma_campagne) do
     create :campagne, libelle: 'Amiens 18 juin', code: 'A5RC8', compte: Compte.first
   end
-  let!(:campagne) { create :campagne, libelle: 'Rouen 30 mars', code: 'A5ROUEN' }
+  let(:compte_organisation) { create :compte_organisation, email: 'orga@eva.fr' }
+  let!(:campagne) do
+    create :campagne, libelle: 'Rouen 30 mars', code: 'A5ROUEN', compte: compte_organisation
+  end
   let!(:evaluation) { create :evaluation, campagne: campagne }
 
   describe 'index' do
@@ -23,29 +26,48 @@ describe 'Admin - Campagne', type: :feature do
   describe 'création' do
     let!(:questionnaire) { create :questionnaire, libelle: 'Mon QCM' }
 
-    before do
-      visit new_admin_campagne_path
-      fill_in :campagne_libelle, with: 'Belfort, pack demandeur'
+    context 'en organisation' do
+      before do
+        visit new_admin_campagne_path
+        fill_in :campagne_libelle, with: 'Belfort, pack demandeur'
+      end
+
+      context 'génère un code si on en saisit pas' do
+        before do
+          fill_in :campagne_code, with: ''
+          select 'Mon QCM'
+        end
+
+        it do
+          expect { click_on 'Créer' }.to(change { Campagne.count })
+          expect(Campagne.last.code).to be_present
+          expect(Campagne.last.compte).to eq compte_connecte
+          expect(page).to have_content 'Mon QCM'
+        end
+
+        context 'conserve le code saisi si précisé' do
+          before { fill_in :campagne_code, with: 'EUROCKS' }
+          it do
+            expect { click_on 'Créer' }.to(change { Campagne.count })
+            expect(Campagne.last.code).to eq 'EUROCKS'
+          end
+        end
+      end
     end
 
-    context 'génère un code si on en saisit pas' do
+    context 'en administrateur' do
       before do
+        Compte.first.update(role: 'administrateur')
+        visit new_admin_campagne_path
+        fill_in :campagne_libelle, with: 'Belfort, pack demandeur'
         fill_in :campagne_code, with: ''
         select 'Mon QCM'
+        select 'orga@eva.fr'
       end
 
       it do
         expect { click_on 'Créer' }.to(change { Campagne.count })
-        expect(Campagne.last.code).to be_present
-        expect(page).to have_content 'Mon QCM'
-      end
-    end
-
-    context 'conserve le code saisi si précisé' do
-      before { fill_in :campagne_code, with: 'EUROCKS' }
-      it do
-        expect { click_on 'Créer' }.to(change { Campagne.count })
-        expect(Campagne.last.code).to eq 'EUROCKS'
+        expect(Campagne.last.compte).to eq compte_organisation
       end
     end
   end

--- a/spec/features/campagne_spec.rb
+++ b/spec/features/campagne_spec.rb
@@ -3,20 +3,26 @@
 require 'rails_helper'
 
 describe 'Admin - Campagne', type: :feature do
-  before { se_connecter_comme_administrateur }
-  let!(:campagne) { create :campagne, libelle: 'Amiens 18 juin', code: 'A5RC8' }
+  before { se_connecter_comme_organisation }
+  let!(:ma_campagne) do
+    create :campagne, libelle: 'Amiens 18 juin', code: 'A5RC8', compte: Compte.first
+  end
+  let!(:campagne) { create :campagne, libelle: 'Rouen 30 mars', code: 'A5ROUEN' }
   let!(:evaluation) { create :evaluation, campagne: campagne }
 
   describe 'index' do
     before { visit admin_campagnes_path }
+
     it do
       expect(page).to have_content 'Amiens 18 juin'
       expect(page).to have_content 'A5RC8'
+      expect(page).to_not have_content 'Rouen 30 mars'
     end
   end
 
   describe 'création' do
     let!(:questionnaire) { create :questionnaire, libelle: 'Mon QCM' }
+
     before do
       visit new_admin_campagne_path
       fill_in :campagne_libelle, with: 'Belfort, pack demandeur'
@@ -47,6 +53,7 @@ describe 'Admin - Campagne', type: :feature do
   describe 'show' do
     let(:situation) { create :situation_inventaire }
     before do
+      Compte.first.update(role: 'administrateur')
       campagne.situations_configurations.create! situation: situation
       visit admin_campagne_path campagne
     end

--- a/spec/features/evaluation_spec.rb
+++ b/spec/features/evaluation_spec.rb
@@ -19,6 +19,11 @@ describe 'Admin - Evaluation', type: :feature do
       visit admin_evaluations_path
       expect(page).to have_content 'Paris 2019'
       expect(page).to_not have_content 'Rouen 2019'
+
+      within('#filters_sidebar_section') do
+        expect(page).to have_content 'Paris 2019'
+        expect(page).to_not have_content 'Rouen 2019'
+      end
     end
   end
 end

--- a/spec/features/evaluation_spec.rb
+++ b/spec/features/evaluation_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe 'Admin - Evaluation', type: :feature do
+  before(:each) { se_connecter_comme_organisation }
+
+  context "en tant qu'organisation" do
+    let(:compte_rouen) { create :compte, role: 'organisation' }
+    let(:campagne_rouen) { create :campagne, compte: compte_rouen, libelle: 'Rouen 2019' }
+    let!(:evaluation) { create :evaluation, campagne: campagne_rouen }
+
+    let(:ma_campagne) do
+      create :campagne, compte: Compte.first, libelle: 'Paris 2019', code: 'paris2019'
+    end
+    let!(:mon_evaluation) { create :evaluation, campagne: ma_campagne }
+
+    it 'Je ne vois que les évaluations liées à mes campagnes' do
+      visit admin_evaluations_path
+      expect(page).to have_content 'Paris 2019'
+      expect(page).to_not have_content 'Rouen 2019'
+    end
+  end
+end

--- a/spec/models/compte_spec.rb
+++ b/spec/models/compte_spec.rb
@@ -15,6 +15,7 @@ describe Compte do
       it { is_expected.to be_able_to(:manage, :all) }
       it { is_expected.to_not be_able_to(%i[destroy create], Evaluation.new) }
       it { is_expected.to_not be_able_to(:create, Evenement.new) }
+      it { is_expected.to be_able_to(:manage, Campagne) }
     end
 
     context 'Compte organisation' do

--- a/spec/models/compte_spec.rb
+++ b/spec/models/compte_spec.rb
@@ -15,7 +15,8 @@ describe Compte do
       it { is_expected.to be_able_to(:manage, :all) }
       it { is_expected.to_not be_able_to(%i[destroy create], Evaluation.new) }
       it { is_expected.to_not be_able_to(:create, Evenement.new) }
-      it { is_expected.to be_able_to(:manage, Campagne) }
+      it { is_expected.to be_able_to(:read, Evenement.new) }
+      it { is_expected.to be_able_to(:manage, Campagne.new) }
     end
 
     context 'Compte organisation' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -40,4 +40,12 @@ RSpec.configure do |config|
     fill_in :compte_password, with: 'password'
     click_on 'Se connecter'
   end
+
+  def se_connecter_comme_organisation
+    Compte.create(email: 'organisation@exemple.fr', password: 'password', role: 'organisation')
+    visit '/admin'
+    fill_in :compte_email, with: 'organisation@exemple.fr'
+    fill_in :compte_password, with: 'password'
+    click_on 'Se connecter'
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -34,18 +34,18 @@ RSpec.configure do |config|
   config.shared_context_metadata_behavior = :apply_to_host_groups
 
   def se_connecter_comme_administrateur
-    Compte.create(email: 'administrateur@exemple.fr', password: 'password', role: 'administrateur')
-    visit '/admin'
-    fill_in :compte_email, with: 'administrateur@exemple.fr'
-    fill_in :compte_password, with: 'password'
-    click_on 'Se connecter'
+    connecte create(:compte_admin, email: 'admin@exemple.fr', password: 'password')
   end
 
   def se_connecter_comme_organisation
-    Compte.create(email: 'organisation@exemple.fr', password: 'password', role: 'organisation')
+    connecte create(:compte_organisation, email: 'organisation@exemple.fr', password: 'password')
+  end
+
+  def connecte(compte)
     visit '/admin'
-    fill_in :compte_email, with: 'organisation@exemple.fr'
-    fill_in :compte_password, with: 'password'
+    fill_in :compte_email, with: compte.email
+    fill_in :compte_password, with: compte.password
     click_on 'Se connecter'
+    compte
   end
 end


### PR DESCRIPTION
Contribue à la  #119 

Un `Compte` « organisation » n'a accès qu'aux `Evaluation` liées aux `Campagne` qu'il a créée. Même chose pour les `Evenement`.