### PR TITLE
Supprime l'utilisation d'openstack pour stocker les fichiers sur la prod

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,6 @@ gem 'puma', '~> 4.0'
 gem 'activeadmin'
 gem 'activeadmin_addons'
 gem 'activeadmin_reorderable'
-gem 'activestorage-openstack'
 gem 'acts_as_list'
 gem 'bootsnap', '>= 1.1.0', require: false
 gem 'bootstrap', '~> 4.3', '>= 4.3.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -58,15 +58,6 @@ GEM
       actionpack (= 5.2.3)
       activerecord (= 5.2.3)
       marcel (~> 0.3.1)
-    activestorage-openstack (0.5.0)
-      concurrent-ruby (~> 1.0, >= 1.0.2)
-      fog-openstack (~> 0.3)
-      i18n (>= 0.7, < 2)
-      marcel
-      mime-types
-      minitest (~> 5.1)
-      rails (~> 5.2.0)
-      tzinfo (~> 1.1)
     activesupport (5.2.3)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 0.7, < 2)
@@ -122,7 +113,6 @@ GEM
       warden (~> 1.2.3)
     diff-lcs (1.3)
     erubi (1.8.0)
-    excon (0.64.0)
     execjs (2.7.0)
     factory_bot (5.0.2)
       activesupport (>= 4.2.0)
@@ -130,18 +120,6 @@ GEM
       factory_bot (~> 5.0.2)
       railties (>= 4.2.0)
     ffi (1.11.1)
-    fog-core (2.1.0)
-      builder
-      excon (~> 0.58)
-      formatador (~> 0.2)
-      mime-types
-    fog-json (1.2.0)
-      fog-core
-      multi_json (~> 1.10)
-    fog-openstack (0.3.10)
-      fog-core (>= 1.45, <= 2.1.0)
-      fog-json (>= 1.0)
-      ipaddress (>= 0.8)
     formatador (0.2.5)
     formtastic (3.1.5)
       actionpack (>= 3.2.13)
@@ -175,7 +153,6 @@ GEM
       has_scope (~> 0.6)
       railties (>= 5.0, < 6.0)
       responders (~> 2.0)
-    ipaddress (0.8.3)
     jaro_winkler (1.5.3)
     jquery-rails (4.3.5)
       rails-dom-testing (>= 1, < 3)
@@ -209,9 +186,6 @@ GEM
     marcel (0.3.3)
       mimemagic (~> 0.3.2)
     method_source (0.9.2)
-    mime-types (3.2.2)
-      mime-types-data (~> 3.2015)
-    mime-types-data (3.2019.0331)
     mimemagic (0.3.3)
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)
@@ -219,7 +193,6 @@ GEM
       libv8 (>= 6.9.411)
     minitest (5.11.3)
     msgpack (1.3.0)
-    multi_json (1.13.1)
     nenv (0.3.0)
     nio4r (2.4.0)
     nokogiri (1.10.3)
@@ -377,7 +350,6 @@ DEPENDENCIES
   activeadmin
   activeadmin_addons
   activeadmin_reorderable
-  activestorage-openstack
   acts_as_list
   bootsnap (>= 1.1.0)
   bootstrap (~> 4.3, >= 4.3.1)

--- a/config/application.rb
+++ b/config/application.rb
@@ -37,7 +37,7 @@ module CompetencesProServeur
     config.middleware.use ActionDispatch::Session::CookieStore
 
     Rails.application.routes.default_url_options = {
-      host: ENV['HOST_URL']
+      host: ENV['HOTE_SERVEUR']
     }
 
     config.middleware.insert_before 0, Rack::Cors do

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -30,7 +30,7 @@ Rails.application.configure do
   # config.action_dispatch.x_sendfile_header = 'X-Accel-Redirect' # for NGINX
 
   # Store uploaded files on the local file system (see config/storage.yml for options)
-  config.active_storage.service = :openstack
+  config.active_storage.service = :local
 
   # Mount Action Cable outside main process or domain
   # config.action_cable.mount_path = nil

--- a/config/storage.yml
+++ b/config/storage.yml
@@ -6,18 +6,6 @@ local:
   service: Disk
   root: <%= Rails.root.join("storage") %>
 
-openstack:
-  service: OpenStack
-  container: <%= ENV.fetch('OPENSTACK_CONTAINER', '') %>
-  credentials:
-    openstack_auth_url: <%= ENV.fetch('OPENSTACK_CONTAINER', '') %>
-    openstack_username: <%= ENV.fetch('OPENSTACK_USERNAME', '') %>
-    openstack_api_key: <%= ENV.fetch('OPENSTACK_API_KEY', '') %>
-    openstack_region: <%= ENV.fetch('OPENSTACK_REGION', '') %>
-    openstack_temp_url_key: <%= ENV.fetch('OPENSTACK_TEMP_URL_KEY', '') %>
-  connection_options:
-    chunk_size: 2097152 # 2MBs - 1MB is the default
-
 # Use rails credentials:edit to set the AWS secrets (as aws:access_key_id|secret_access_key)
 # amazon:
 #   service: S3


### PR DESCRIPTION
On stocke les fichiers directement en local.

J'en ai profité pour renommer la variable `HOST_URL` en `HOTE_SERVEUR` pour correspondre a une variable que l'on a déjà coté déploiement.