### PR TITLE
Compte organisation: empêche la gestion des questions/situations

### DIFF
--- a/app/admin/evenements.rb
+++ b/app/admin/evenements.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 ActiveAdmin.register Evenement do
+  menu if: proc { can? :manage, Compte }
   permit_params :donnees, :session_id, :situation, :nom, :date
 
   filter :situation

--- a/app/admin/questionnaires.rb
+++ b/app/admin/questionnaires.rb
@@ -18,4 +18,14 @@ ActiveAdmin.register Questionnaire do
   show do
     render partial: 'show'
   end
+
+  controller do
+    def scoped_collection
+      if current_compte.administrateur?
+        Questionnaire.all
+      else
+        Campagne.includes(:questionnaire).where(compte: current_compte)
+      end
+    end
+  end
 end

--- a/app/admin/questionnaires.rb
+++ b/app/admin/questionnaires.rb
@@ -18,14 +18,4 @@ ActiveAdmin.register Questionnaire do
   show do
     render partial: 'show'
   end
-
-  controller do
-    def scoped_collection
-      if current_compte.administrateur?
-        Questionnaire.all
-      else
-        Campagne.includes(:questionnaire).where(compte: current_compte)
-      end
-    end
-  end
 end

--- a/app/admin/restitutions.rb
+++ b/app/admin/restitutions.rb
@@ -40,8 +40,10 @@ ActiveAdmin.register Evenement, as: 'Restitutions' do
     column :date
     column '' do |evenement|
       span link_to t('.rapport'), admin_restitution_path(id: evenement)
-      span link_to t('.evenements'),
-                   admin_evenements_path(q: { 'session_id_equals' => evenement.session_id })
+      if can? :manage, Compte
+        span link_to t('.evenements'),
+                     admin_evenements_path(q: { 'session_id_equals' => evenement.session_id })
+      end
     end
   end
 

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -8,6 +8,8 @@ class Ability
     droit_campagne compte
     droit_evaluation compte
     droit_evenement compte
+    droit_situation compte
+    droit_question compte
     cannot :manage, Compte unless compte.administrateur?
   end
 
@@ -27,6 +29,16 @@ class Ability
   def droit_evenement(compte)
     cannot :read, Evenement unless compte.administrateur?
     can :read, Evenement, evaluation: { campagne: { compte_id: compte.id } }
+  end
+
+  def droit_situation(compte)
+    cannot :manage, Situation unless compte.administrateur?
+    can :read, Situation
+  end
+
+  def droit_question(compte)
+    cannot :manage, Question unless compte.administrateur?
+    can :read, Question
   end
 
   def droits_generiques

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -10,6 +10,7 @@ class Ability
     droit_evenement compte
     droit_situation compte
     droit_question compte
+    droit_questionnaire compte
     cannot :manage, Compte unless compte.administrateur?
   end
 
@@ -34,6 +35,14 @@ class Ability
   def droit_situation(compte)
     cannot :manage, Situation unless compte.administrateur?
     can :read, Situation
+  end
+
+  def droit_questionnaire(compte)
+    cannot :manage, Questionnaire unless compte.administrateur?
+    can :read, Questionnaire
+    cannot :destroy, Questionnaire do |q|
+      Campagne.where(questionnaire: q).present?
+    end
   end
 
   def droit_question(compte)

--- a/spec/features/questionnaire_spec.rb
+++ b/spec/features/questionnaire_spec.rb
@@ -5,11 +5,15 @@ require 'rails_helper'
 describe 'Admin - Questionnaire', type: :feature do
   before { se_connecter_comme_administrateur }
   let!(:questionnaire) { create :questionnaire, libelle: 'Numératie et Litératie' }
+  let!(:campagne) { create :campagne, questionnaire: questionnaire }
 
   describe 'index' do
     before { visit admin_questionnaires_path }
     it do
       expect(page).to have_content 'Numératie et Litératie'
+      within '.paginated_collection' do
+        expect(page).to_not have_content 'Supprimer'
+      end
     end
   end
 

--- a/spec/models/compte_spec.rb
+++ b/spec/models/compte_spec.rb
@@ -23,6 +23,8 @@ describe Compte do
       let(:compte) { build :compte, role: 'organisation' }
 
       it { is_expected.to_not be_able_to(:manage, Compte.new) }
+      it { is_expected.to_not be_able_to(%i[destroy create update], Situation.new) }
+      it { is_expected.to_not be_able_to(%i[destroy create update], Question.new) }
     end
   end
 end

--- a/spec/models/compte_spec.rb
+++ b/spec/models/compte_spec.rb
@@ -17,6 +17,7 @@ describe Compte do
       it { is_expected.to_not be_able_to(:create, Evenement.new) }
       it { is_expected.to be_able_to(:read, Evenement.new) }
       it { is_expected.to be_able_to(:manage, Campagne.new) }
+      it { is_expected.to be_able_to(:manage, Questionnaire.new) }
     end
 
     context 'Compte organisation' do
@@ -25,6 +26,8 @@ describe Compte do
       it { is_expected.to_not be_able_to(:manage, Compte.new) }
       it { is_expected.to_not be_able_to(%i[destroy create update], Situation.new) }
       it { is_expected.to_not be_able_to(%i[destroy create update], Question.new) }
+      it { is_expected.to_not be_able_to(:manage, Questionnaire.new) }
+      it { is_expected.to be_able_to(:read, Questionnaire.new) }
     end
   end
 end


### PR DESCRIPTION
Contribue à la #119.
Cette PR vise à limiter les droits des `Compte` `organisation` pour les resources questions, situations et questionnaires.

- [x] Autorise seulement la visualisation des questions/situations
- [x] N'a pas accès au questionnaires 