### PR TITLE
modifie la gestion de l'abandon

### DIFF
--- a/app/models/restitution/controle/attention_concentration.rb
+++ b/app/models/restitution/controle/attention_concentration.rb
@@ -4,6 +4,8 @@ module Restitution
   class Controle
     class AttentionConcentration < Restitution::Competence::Base
       def niveau
+        return ::Competence::NIVEAU_INDETERMINE if @restitution.abandon?
+
         nombre_loupees = @restitution.nombre_loupees
         case nombre_loupees
         when 0 then ::Competence::NIVEAU_4

--- a/app/models/restitution/controle/comparaison_tri.rb
+++ b/app/models/restitution/controle/comparaison_tri.rb
@@ -9,7 +9,7 @@ module Restitution
       end
 
       def niveau
-        return ::Competence::NIVEAU_INDETERMINE if @restitution.evenements.count < 4
+        return ::Competence::NIVEAU_INDETERMINE if @restitution.abandon?
 
         nombre_erreurs = @restitution_hors_4_premiers.nombre_mal_placees
         case nombre_erreurs

--- a/app/models/restitution/controle/rapidite.rb
+++ b/app/models/restitution/controle/rapidite.rb
@@ -4,6 +4,8 @@ module Restitution
   class Controle
     class Rapidite < Restitution::Competence::Base
       def niveau
+        return ::Competence::NIVEAU_INDETERMINE if @restitution.abandon?
+
         nombre_erreurs = @restitution.nombre_non_triees
         case nombre_erreurs
         when 0 then ::Competence::NIVEAU_4

--- a/config/locales/views/restitutions.yml
+++ b/config/locales/views/restitutions.yml
@@ -58,7 +58,7 @@ fr:
         abandon: Abandon
         echec: Échec
         termine: Terminé
-        indetermine: Indéterminée
+        indetermine: Indéterminée car abandon
       restitution_inventaire:
         ouverture_contenant: Ouvertures de contenant
         essai: Essai %{count}

--- a/spec/models/restitution/controle/attention_concentration_spec.rb
+++ b/spec/models/restitution/controle/attention_concentration_spec.rb
@@ -5,49 +5,62 @@ require 'rails_helper'
 describe Restitution::Controle::AttentionConcentration do
   let(:restitution) { double }
 
-  context "lorsqu'il n'y a pas de loupées" do
-    it 'a le niveau 4' do
-      expect(restitution).to receive(:nombre_loupees).and_return(0)
-      expect(
-        described_class.new(restitution).niveau
-      ).to eql(Competence::NIVEAU_4)
+  context 'sans abandon' do
+    before { allow(restitution).to receive(:abandon?).and_return(false) }
+
+    context "lorsqu'il n'y a pas de loupées" do
+      it 'a le niveau 4' do
+        expect(restitution).to receive(:nombre_loupees).and_return(0)
+        expect(
+          described_class.new(restitution).niveau
+        ).to eql(Competence::NIVEAU_4)
+      end
+    end
+
+    context "lorsqu'il y a un loupée" do
+      it 'a le niveau 3' do
+        expect(restitution).to receive(:nombre_loupees).and_return(1)
+
+        expect(
+          described_class.new(restitution).niveau
+        ).to eql(Competence::NIVEAU_3)
+      end
+    end
+
+    context "lorsqu'il y a deux pièces loupées" do
+      it 'a le niveau 2' do
+        expect(restitution).to receive(:nombre_loupees).and_return(2)
+        expect(
+          described_class.new(restitution).niveau
+        ).to eql(Competence::NIVEAU_2)
+      end
+    end
+
+    context "lorsqu'il y a trois pièces loupées" do
+      it 'a le niveau 1' do
+        expect(restitution).to receive(:nombre_loupees).and_return(3)
+        expect(
+          described_class.new(restitution).niveau
+        ).to eql(Competence::NIVEAU_1)
+      end
+    end
+
+    context "lorsqu'il y a quatre pièces loupées" do
+      it 'a le niveau 1' do
+        expect(restitution).to receive(:nombre_loupees).and_return(4)
+        expect(
+          described_class.new(restitution).niveau
+        ).to eql(Competence::NIVEAU_1)
+      end
     end
   end
 
-  context "lorsqu'il y a un loupée" do
-    it 'a le niveau 3' do
-      expect(restitution).to receive(:nombre_loupees).and_return(1)
-
+  context 'avec abandon' do
+    it 'a un niveau indeterminé' do
+      expect(restitution).to receive(:abandon?).and_return(true)
       expect(
         described_class.new(restitution).niveau
-      ).to eql(Competence::NIVEAU_3)
-    end
-  end
-
-  context "lorsqu'il y a deux pièces loupées" do
-    it 'a le niveau 2' do
-      expect(restitution).to receive(:nombre_loupees).and_return(2)
-      expect(
-        described_class.new(restitution).niveau
-      ).to eql(Competence::NIVEAU_2)
-    end
-  end
-
-  context "lorsqu'il y a trois pièces loupées" do
-    it 'a le niveau 1' do
-      expect(restitution).to receive(:nombre_loupees).and_return(3)
-      expect(
-        described_class.new(restitution).niveau
-      ).to eql(Competence::NIVEAU_1)
-    end
-  end
-
-  context "lorsqu'il y a quatre pièces loupées" do
-    it 'a le niveau 1' do
-      expect(restitution).to receive(:nombre_loupees).and_return(4)
-      expect(
-        described_class.new(restitution).niveau
-      ).to eql(Competence::NIVEAU_1)
+      ).to eql(Competence::NIVEAU_INDETERMINE)
     end
   end
 end

--- a/spec/models/restitution/controle/comparaison_tri_spec.rb
+++ b/spec/models/restitution/controle/comparaison_tri_spec.rb
@@ -7,57 +7,53 @@ describe Restitution::Controle::ComparaisonTri do
   let(:restitution_hors_4_premiers) { double }
 
   before(:each) do
+    allow(restitution).to receive(:abandon?).and_return(false)
     allow(restitution).to receive(:evenements).and_return([1, 2, 3, 4])
     allow(restitution).to receive(:enleve_premiers_evenements_pieces)
       .with(4).and_return(restitution_hors_4_premiers)
   end
 
-  context "lorsqu'il n'y a pas d'erreurs ou de ratées" do
-    it 'a le niveau 4' do
-      expect(restitution_hors_4_premiers).to receive(:nombre_mal_placees).and_return(0)
-      expect(
-        described_class.new(restitution).niveau
-      ).to eql(Competence::NIVEAU_4)
+  context 'sans abandon' do
+    context "lorsqu'il n'y a pas d'erreurs ou de ratées" do
+      it 'a le niveau 4' do
+        expect(restitution_hors_4_premiers).to receive(:nombre_mal_placees).and_return(0)
+        expect(
+          described_class.new(restitution).niveau
+        ).to eql(Competence::NIVEAU_4)
+      end
+    end
+
+    context "lorsqu'il y a une pièce mal placée hors 4 premières" do
+      it 'a le niveau 3' do
+        expect(restitution_hors_4_premiers).to receive(:nombre_mal_placees).and_return(1)
+        expect(
+          described_class.new(restitution).niveau
+        ).to eql(Competence::NIVEAU_3)
+      end
+    end
+
+    context "lorsqu'il y a deux pièces mal placées hors 4 premières" do
+      it 'a le niveau 2' do
+        expect(restitution_hors_4_premiers).to receive(:nombre_mal_placees).and_return(2)
+        expect(
+          described_class.new(restitution).niveau
+        ).to eql(Competence::NIVEAU_2)
+      end
+    end
+
+    context "lorsqu'il y a trois pièces mal placéee hors 4 premières" do
+      it 'a le niveau 1' do
+        expect(restitution_hors_4_premiers).to receive(:nombre_mal_placees).and_return(3)
+        expect(
+          described_class.new(restitution).niveau
+        ).to eql(Competence::NIVEAU_1)
+      end
     end
   end
 
-  context "lorsqu'il y a une pièce mal placée hors 4 premières" do
-    it 'a le niveau 3' do
-      expect(restitution_hors_4_premiers).to receive(:nombre_mal_placees).and_return(1)
-      expect(
-        described_class.new(restitution).niveau
-      ).to eql(Competence::NIVEAU_3)
-    end
-  end
-
-  context "lorsqu'il y a deux pièces mal placées hors 4 premières" do
-    it 'a le niveau 2' do
-      expect(restitution_hors_4_premiers).to receive(:nombre_mal_placees).and_return(2)
-      expect(
-        described_class.new(restitution).niveau
-      ).to eql(Competence::NIVEAU_2)
-    end
-  end
-
-  context "lorsqu'il y a trois pièces mal placéee hors 4 premières" do
-    it 'a le niveau 1' do
-      expect(restitution_hors_4_premiers).to receive(:nombre_mal_placees).and_return(3)
-      expect(
-        described_class.new(restitution).niveau
-      ).to eql(Competence::NIVEAU_1)
-    end
-  end
-
-  context "lorsqu'il n'y a que 3 événements" do
-    let(:evenements) do
-      [
-        build(:evenement_piece_bien_placee),
-        build(:evenement_piece_mal_placee)
-      ]
-    end
-
+  context 'avec abandon' do
     it 'a le niveau indéfini' do
-      expect(restitution).to receive(:evenements).and_return([1, 2, 3])
+      expect(restitution).to receive(:abandon?).and_return(true)
       expect(
         described_class.new(restitution).niveau
       ).to eql(Competence::NIVEAU_INDETERMINE)

--- a/spec/models/restitution/controle/rapidite_spec.rb
+++ b/spec/models/restitution/controle/rapidite_spec.rb
@@ -5,39 +5,52 @@ require 'rails_helper'
 describe Restitution::Controle::Rapidite do
   let(:restitution) { double }
 
-  context "lorsqu'il n'y a pas de ratées" do
-    it 'a le niveau 4' do
-      expect(restitution).to receive(:nombre_non_triees).and_return(0)
-      expect(
-        described_class.new(restitution).niveau
-      ).to eql(Competence::NIVEAU_4)
+  context 'sans abandon' do
+    before { allow(restitution).to receive(:abandon?).and_return(false) }
+
+    context "lorsqu'il n'y a pas de ratées" do
+      it 'a le niveau 4' do
+        expect(restitution).to receive(:nombre_non_triees).and_return(0)
+        expect(
+          described_class.new(restitution).niveau
+        ).to eql(Competence::NIVEAU_4)
+      end
+    end
+
+    context "lorsqu'il y a une pièce ratée" do
+      it 'a le niveau 3' do
+        expect(restitution).to receive(:nombre_non_triees).and_return(1)
+        expect(
+          described_class.new(restitution).niveau
+        ).to eql(Competence::NIVEAU_3)
+      end
+    end
+
+    context "lorsqu'il y a deux pièces ratées" do
+      it 'a le niveau 2' do
+        expect(restitution).to receive(:nombre_non_triees).and_return(2)
+        expect(
+          described_class.new(restitution).niveau
+        ).to eql(Competence::NIVEAU_2)
+      end
+    end
+
+    context "lorsqu'il y a trois pièces ratées" do
+      it 'a le niveau 1' do
+        expect(restitution).to receive(:nombre_non_triees).and_return(3)
+        expect(
+          described_class.new(restitution).niveau
+        ).to eql(Competence::NIVEAU_1)
+      end
     end
   end
 
-  context "lorsqu'il y a une pièce ratée" do
-    it 'a le niveau 3' do
-      expect(restitution).to receive(:nombre_non_triees).and_return(1)
+  context 'avec abandon' do
+    it 'a un niveau indeterminé' do
+      expect(restitution).to receive(:abandon?).and_return(true)
       expect(
         described_class.new(restitution).niveau
-      ).to eql(Competence::NIVEAU_3)
-    end
-  end
-
-  context "lorsqu'il y a deux pièces ratées" do
-    it 'a le niveau 2' do
-      expect(restitution).to receive(:nombre_non_triees).and_return(2)
-      expect(
-        described_class.new(restitution).niveau
-      ).to eql(Competence::NIVEAU_2)
-    end
-  end
-
-  context "lorsqu'il y a trois pièces ratées" do
-    it 'a le niveau 1' do
-      expect(restitution).to receive(:nombre_non_triees).and_return(3)
-      expect(
-        described_class.new(restitution).niveau
-      ).to eql(Competence::NIVEAU_1)
+      ).to eql(Competence::NIVEAU_INDETERMINE)
     end
   end
 end

--- a/spec/models/restitution/inventaire/organisation_methode_spec.rb
+++ b/spec/models/restitution/inventaire/organisation_methode_spec.rb
@@ -45,8 +45,8 @@ describe Restitution::Inventaire::OrganisationMethode do
     end
   end
 
-  context 'en cas de non reussite' do
-    it 'a le niveau indetermine' do
+  context 'en cas de non réussite' do
+    it 'a le niveau indéterminé' do
       expect(restitution).to receive(:reussite?).and_return(false)
       expect(
         described_class.new(restitution).niveau


### PR DESCRIPTION
Si l'évalué abandonne alors toute ses compétences passent au niveau indéterminée excepté persévérance et compréhension de consigne qui garde leur mode de calcul actuel.

Fix #141 