### PR TITLE
[Inventaire] Ajoute le nombre d'ouverture de contenants dans la restitution globale.

### DIFF
--- a/app/views/admin/restitution_globale/_inventaire.html.arb
+++ b/app/views/admin/restitution_globale/_inventaire.html.arb
@@ -4,4 +4,6 @@ div class: 'row inventaire' do
   render 'badge', label: t('.efficience'), valeur: formate_efficience(restitution.efficience)
   render 'badge', label: t('.duree'), valeur: formate_duree(restitution.temps_total)
   render 'badge', label: t('.nombre_essais'), valeur: restitution.nombre_essais_validation
+  render 'badge', label: t('.nombre_ouverture_contenant'),
+                  valeur: restitution.nombre_ouverture_contenant
 end

--- a/config/locales/views/restitutions.yml
+++ b/config/locales/views/restitutions.yml
@@ -12,6 +12,7 @@ fr:
       inventaire:
         <<: *commun
         nombre_essais: Nbre d'essais
+        nombre_ouverture_contenant: Nbre d'ouverture de contenants
       questions:
         abstention: Ne sait pas
         bon: Correct


### PR DESCRIPTION
![Screenshot_2019-09-02 Restitution Globale Compétences Pro Serveur](https://user-images.githubusercontent.com/86659/64112928-1cdd7580-cd89-11e9-8684-8228760831c3.png)

Fix #149 