### PR TITLE
change les id en uuid dans la base de données

### DIFF
--- a/app/admin/evaluation.rb
+++ b/app/admin/evaluation.rb
@@ -3,6 +3,7 @@
 ActiveAdmin.register Evaluation do
   filter :campagne, collection: proc { evaluations_visibles }
   filter :created_at
+  config.sort_order = 'created_at_desc'
 
   index do
     column :nom

--- a/app/admin/evenements.rb
+++ b/app/admin/evenements.rb
@@ -3,6 +3,7 @@
 ActiveAdmin.register Evenement do
   menu if: proc { can? :manage, Compte }
   permit_params :donnees, :session_id, :situation, :nom, :date
+  config.sort_order = 'created_at_desc'
 
   filter :situation
   filter :session_id

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -2,4 +2,5 @@
 
 class ApplicationRecord < ActiveRecord::Base
   self.abstract_class = true
+  default_scope { order(created_at: :asc) }
 end

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -2,5 +2,4 @@
 
 class ApplicationRecord < ActiveRecord::Base
   self.abstract_class = true
-  default_scope { order(created_at: :asc) }
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -35,6 +35,11 @@ module CompetencesProServeur
     config.middleware.use ActionDispatch::Cookies
     config.middleware.use ActionDispatch::Session::CookieStore
 
+    config.generators do |g|
+      g.orm :active_record, primary_key_type: :uuid
+      g.orm :active_record, foreign_key_type: :uuid
+    end
+
     Rails.application.routes.default_url_options = {
       host: ENV['HOTE_SERVEUR'],
       protocol: ENV['PROTOCOLE_SERVEUR']

--- a/db/migrate/20190709072254_affecte_evaluation_aux_evenements.rb
+++ b/db/migrate/20190709072254_affecte_evaluation_aux_evenements.rb
@@ -1,6 +1,6 @@
 class AffecteEvaluationAuxEvenements < ActiveRecord::Migration[5.2]
   def change
-    Evenement.select(:utilisateur).distinct.each do |evenement|
+    Evenement.unscoped.select(:utilisateur).distinct.each do |evenement|
       next if evenement.utilisateur.nil?
       evaluation = Evaluation.create(nom: evenement.utilisateur)
       Evenement.where(utilisateur: evenement.utilisateur).update_all(evaluation_id: evaluation.id)

--- a/db/migrate/20190923161436_enable_extension_for_uuid.rb
+++ b/db/migrate/20190923161436_enable_extension_for_uuid.rb
@@ -1,0 +1,5 @@
+class EnableExtensionForUuid < ActiveRecord::Migration[5.2]
+  def change
+    enable_extension 'pgcrypto' unless extension_enabled?('pgcrypto')
+  end
+end

--- a/db/migrate/20190923182330_add_timestamps_to_questionnaire_question.rb
+++ b/db/migrate/20190923182330_add_timestamps_to_questionnaire_question.rb
@@ -1,0 +1,6 @@
+class AddTimestampsToQuestionnaireQuestion < ActiveRecord::Migration[5.2]
+  def change
+    add_column :questionnaires_questions, :created_at, :datetime
+    add_column :questionnaires_questions, :updated_at, :datetime
+  end
+end

--- a/db/migrate/20190923190825_ajoute_uuid_aux_tables.rb
+++ b/db/migrate/20190923190825_ajoute_uuid_aux_tables.rb
@@ -1,6 +1,9 @@
 class AjouteUuidAuxTables < ActiveRecord::Migration[5.2]
   def change
     tables = %w[
+      active_admin_comments
+      active_storage_attachments
+      active_storage_blobs
       campagnes
       choix
       comptes

--- a/db/migrate/20190923190825_ajoute_uuid_aux_tables.rb
+++ b/db/migrate/20190923190825_ajoute_uuid_aux_tables.rb
@@ -1,0 +1,20 @@
+class AjouteUuidAuxTables < ActiveRecord::Migration[5.2]
+  def change
+    tables = %w[
+      campagnes
+      choix
+      comptes
+      evaluations
+      evenements
+      questionnaires
+      questionnaires_questions
+      questions
+      situations
+      situations_configurations
+    ]
+    tables.each do |table|
+      add_column table, :uuid, :uuid, default: "gen_random_uuid()", null: false
+    end
+
+  end
+end

--- a/db/migrate/20190923191333_migre_cles_etrangeres.rb
+++ b/db/migrate/20190923191333_migre_cles_etrangeres.rb
@@ -10,12 +10,13 @@ def up
     id_to_uuid('questionnaires_questions', 'question', 'question')
     id_to_uuid('situations_configurations', 'campagne', 'campagne')
     id_to_uuid('situations_configurations', 'situation', 'situation')
+    id_to_uuid('active_storage_attachments', 'blob', 'blob', klass: ActiveStorage::Attachment, relation_klass: ActiveStorage::Blob)
   end
 
-  def id_to_uuid(table_name, relation_name, relation_class)
+  def id_to_uuid(table_name, relation_name, relation_class, klass: nil, relation_klass: nil)
     table_name = table_name.to_sym
-    klass = table_name.to_s.classify.constantize
-    relation_klass = relation_class.to_s.classify.constantize
+    klass ||= table_name.to_s.classify.constantize
+    relation_klass ||= relation_class.to_s.classify.constantize
     foreign_key = "#{relation_name}_id".to_sym
     new_foreign_key = "#{relation_name}_uuid".to_sym
 

--- a/db/migrate/20190923191333_migre_cles_etrangeres.rb
+++ b/db/migrate/20190923191333_migre_cles_etrangeres.rb
@@ -1,0 +1,33 @@
+class MigreClesEtrangeres < ActiveRecord::Migration[5.2]
+def up
+    id_to_uuid('campagnes', 'questionnaire', 'questionnaire')
+    id_to_uuid('campagnes', 'compte', 'questionnaire')
+    id_to_uuid('choix', 'question', 'question')
+    id_to_uuid('evaluations', 'campagne', 'campagne')
+    id_to_uuid('evenements', 'evaluation', 'evaluation')
+    id_to_uuid('evenements', 'situation', 'situation')
+    id_to_uuid('questionnaires_questions', 'questionnaire', 'questionnaire')
+    id_to_uuid('questionnaires_questions', 'question', 'question')
+    id_to_uuid('situations_configurations', 'campagne', 'campagne')
+    id_to_uuid('situations_configurations', 'situation', 'situation')
+  end
+
+  def id_to_uuid(table_name, relation_name, relation_class)
+    table_name = table_name.to_sym
+    klass = table_name.to_s.classify.constantize
+    relation_klass = relation_class.to_s.classify.constantize
+    foreign_key = "#{relation_name}_id".to_sym
+    new_foreign_key = "#{relation_name}_uuid".to_sym
+
+    add_column table_name, new_foreign_key, :uuid
+
+    klass.where.not(foreign_key => nil).each do |record|
+      if associated_record = relation_klass.find_by(id: record.send(foreign_key))
+        record.update_column(new_foreign_key, associated_record.uuid)
+      end
+    end
+
+    remove_column table_name, foreign_key
+    rename_column table_name, new_foreign_key, foreign_key
+  end
+end

--- a/db/migrate/20190923191333_migre_cles_etrangeres.rb
+++ b/db/migrate/20190923191333_migre_cles_etrangeres.rb
@@ -1,7 +1,7 @@
 class MigreClesEtrangeres < ActiveRecord::Migration[5.2]
 def up
     id_to_uuid('campagnes', 'questionnaire', 'questionnaire')
-    id_to_uuid('campagnes', 'compte', 'questionnaire')
+    id_to_uuid('campagnes', 'compte', 'compte')
     id_to_uuid('choix', 'question', 'question')
     id_to_uuid('evaluations', 'campagne', 'campagne')
     id_to_uuid('evenements', 'evaluation', 'evaluation')

--- a/db/migrate/20190923191334_migre_les_cles_etrageres_polymorphiques.rb
+++ b/db/migrate/20190923191334_migre_les_cles_etrageres_polymorphiques.rb
@@ -1,0 +1,25 @@
+class MigreLesClesEtrageresPolymorphiques < ActiveRecord::Migration[5.2]
+  def change
+    id_to_uuid_polymorphic('active_admin_comments', ActiveAdmin::Comment, 'resource')
+    id_to_uuid_polymorphic('active_storage_attachments', ActiveStorage::Attachment, 'record')
+  end
+
+  def id_to_uuid_polymorphic(table_name, klass, relation_name)
+    table_name = table_name.to_sym
+    foreign_key = "#{relation_name}_id".to_sym
+    new_foreign_key = "#{relation_name}_uuid".to_sym
+
+    add_column table_name, new_foreign_key, :uuid
+
+    klass.where.not(foreign_key => nil).each do |record|
+      relation_klass = record.send("#{relation_name}_type").classify.constantize
+      if associated_record = relation_klass.find_by(id: record.send(foreign_key))
+        record.update_column(new_foreign_key, associated_record.uuid)
+      end
+    end
+
+    remove_column table_name, foreign_key
+    rename_column table_name, new_foreign_key, foreign_key
+
+  end
+end

--- a/db/migrate/20190923191335_migre_les_evenements_reponse.rb
+++ b/db/migrate/20190923191335_migre_les_evenements_reponse.rb
@@ -1,0 +1,16 @@
+class MigreLesEvenementsReponse < ActiveRecord::Migration[6.0]
+  def change
+    Evenement.where(nom: 'reponse').find_each do |evenement|
+      anciennes_donnees = evenement.donnees
+      nouvelles_donnees = anciennes_donnees.clone
+      if anciennes_donnees['question'].is_a? Integer
+        nouvelles_donnees['question'] = Question.find(anciennes_donnees['question']).uuid
+      end
+      if anciennes_donnees['reponse'].is_a? Integer
+        nouvelles_donnees['reponse'] = Choix.find(anciennes_donnees['reponse']).uuid
+      end
+      evenement.donnees = nouvelles_donnees
+      evenement.save!(validate: false)
+    end
+  end
+end

--- a/db/migrate/20190923192520_passe_les_uuid_en_id.rb
+++ b/db/migrate/20190923192520_passe_les_uuid_en_id.rb
@@ -1,6 +1,9 @@
 class PasseLesUuidEnId < ActiveRecord::Migration[5.2]
 def up
     tables = %w[
+      active_admin_comments
+      active_storage_attachments
+      active_storage_blobs
       campagnes
       choix
       comptes

--- a/db/migrate/20190923192520_passe_les_uuid_en_id.rb
+++ b/db/migrate/20190923192520_passe_les_uuid_en_id.rb
@@ -1,0 +1,22 @@
+class PasseLesUuidEnId < ActiveRecord::Migration[5.2]
+def up
+    tables = %w[
+      campagnes
+      choix
+      comptes
+      evaluations
+      evenements
+      questionnaires
+      questionnaires_questions
+      questions
+      situations
+      situations_configurations
+    ]
+
+    tables.each do |table|
+      remove_column table, :id
+      rename_column table, :uuid, :id
+      execute "ALTER TABLE #{table} ADD PRIMARY KEY (id);"
+    end
+  end
+end

--- a/db/migrate/20190923200751_remet_les_cles_etrangeres.rb
+++ b/db/migrate/20190923200751_remet_les_cles_etrangeres.rb
@@ -1,0 +1,13 @@
+class RemetLesClesEtrangeres < ActiveRecord::Migration[5.2]
+  def change
+    add_foreign_key 'campagnes', 'comptes'
+    add_foreign_key 'campagnes', 'questionnaires'
+    add_foreign_key 'choix', 'questions'
+    add_foreign_key 'evaluations', 'campagnes'
+    add_foreign_key 'evenements', 'evaluations'
+    add_foreign_key 'evenements', 'situations'
+    add_foreign_key 'questionnaires_questions', 'questionnaires'
+    add_foreign_key 'questionnaires_questions', 'questions'
+    add_foreign_key 'situations_configurations', 'campagnes'
+  end
+end

--- a/db/migrate/20190923200751_remet_les_cles_etrangeres.rb
+++ b/db/migrate/20190923200751_remet_les_cles_etrangeres.rb
@@ -9,5 +9,6 @@ class RemetLesClesEtrangeres < ActiveRecord::Migration[5.2]
     add_foreign_key 'questionnaires_questions', 'questionnaires'
     add_foreign_key 'questionnaires_questions', 'questions'
     add_foreign_key 'situations_configurations', 'campagnes'
+    add_foreign_key 'active_storage_attachments', 'active_storage_blobs', column: 'blob_id'
   end
 end

--- a/db/migrate/20190923210147_remet_les_index.rb
+++ b/db/migrate/20190923210147_remet_les_index.rb
@@ -1,5 +1,6 @@
 class RemetLesIndex < ActiveRecord::Migration[5.2]
   def change
+    add_index 'active_storage_attachments', 'blob_id'
     add_index 'campagnes', 'questionnaire_id'
     add_index 'campagnes', 'compte_id'
     add_index 'choix', 'question_id'
@@ -10,5 +11,7 @@ class RemetLesIndex < ActiveRecord::Migration[5.2]
     add_index 'questionnaires_questions', 'question_id'
     add_index 'situations_configurations', 'campagne_id'
     add_index 'situations_configurations', 'situation_id'
+    add_index 'active_admin_comments', ["resource_type", "resource_id"]
+    add_index 'active_storage_attachments', ["record_type", "record_id", "name", "blob_id"], name: 'index_active_storage_attachments_uniqueness', unique: true
   end
 end

--- a/db/migrate/20190923210147_remet_les_index.rb
+++ b/db/migrate/20190923210147_remet_les_index.rb
@@ -1,0 +1,14 @@
+class RemetLesIndex < ActiveRecord::Migration[5.2]
+  def change
+    add_index 'campagnes', 'questionnaire_id'
+    add_index 'campagnes', 'compte_id'
+    add_index 'choix', 'question_id'
+    add_index 'evaluations', 'campagne_id'
+    add_index 'evenements', 'evaluation_id'
+    add_index 'evenements', 'situation_id'
+    add_index 'questionnaires_questions', 'questionnaire_id'
+    add_index 'questionnaires_questions', 'question_id'
+    add_index 'situations_configurations', 'campagne_id'
+    add_index 'situations_configurations', 'situation_id'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,10 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_07_29_084304) do
+ActiveRecord::Schema.define(version: 2019_09_23_210147) do
 
   # These are extensions that must be enabled in order to support this database
+  enable_extension "pgcrypto"
   enable_extension "plpgsql"
 
   create_table "active_admin_comments", force: :cascade do |t|
@@ -50,28 +51,28 @@ ActiveRecord::Schema.define(version: 2019_07_29_084304) do
     t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
   end
 
-  create_table "campagnes", force: :cascade do |t|
+  create_table "campagnes", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "libelle"
     t.string "code"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.bigint "questionnaire_id"
-    t.bigint "compte_id"
+    t.uuid "questionnaire_id"
+    t.uuid "compte_id"
     t.index ["compte_id"], name: "index_campagnes_on_compte_id"
     t.index ["questionnaire_id"], name: "index_campagnes_on_questionnaire_id"
   end
 
-  create_table "choix", force: :cascade do |t|
+  create_table "choix", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "intitule"
-    t.bigint "question_id"
     t.integer "type_choix"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "position"
+    t.uuid "question_id"
     t.index ["question_id"], name: "index_choix_on_question_id"
   end
 
-  create_table "comptes", force: :cascade do |t|
+  create_table "comptes", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
     t.string "reset_password_token"
@@ -84,42 +85,44 @@ ActiveRecord::Schema.define(version: 2019_07_29_084304) do
     t.index ["reset_password_token"], name: "index_comptes_on_reset_password_token", unique: true
   end
 
-  create_table "evaluations", force: :cascade do |t|
+  create_table "evaluations", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "nom"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.bigint "campagne_id"
+    t.uuid "campagne_id"
     t.index ["campagne_id"], name: "index_evaluations_on_campagne_id"
   end
 
-  create_table "evenements", force: :cascade do |t|
+  create_table "evenements", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "nom"
-    t.jsonb "donnees", default: {}, null: false
+    t.jsonb "donnees", default: "{}", null: false
     t.datetime "date"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "session_id"
-    t.bigint "evaluation_id"
-    t.bigint "situation_id"
+    t.uuid "evaluation_id"
+    t.uuid "situation_id"
     t.index ["evaluation_id"], name: "index_evenements_on_evaluation_id"
     t.index ["situation_id"], name: "index_evenements_on_situation_id"
   end
 
-  create_table "questionnaires", force: :cascade do |t|
+  create_table "questionnaires", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "libelle"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
 
-  create_table "questionnaires_questions", force: :cascade do |t|
-    t.bigint "questionnaire_id"
-    t.bigint "question_id"
+  create_table "questionnaires_questions", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.integer "position"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.uuid "questionnaire_id"
+    t.uuid "question_id"
     t.index ["question_id"], name: "index_questionnaires_questions_on_question_id"
     t.index ["questionnaire_id"], name: "index_questionnaires_questions_on_questionnaire_id"
   end
 
-  create_table "questions", force: :cascade do |t|
+  create_table "questions", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "intitule"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -132,19 +135,19 @@ ActiveRecord::Schema.define(version: 2019_07_29_084304) do
     t.string "libelle"
   end
 
-  create_table "situations", force: :cascade do |t|
+  create_table "situations", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "libelle"
     t.string "nom_technique"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
 
-  create_table "situations_configurations", force: :cascade do |t|
-    t.bigint "campagne_id"
-    t.bigint "situation_id"
+  create_table "situations_configurations", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.integer "position"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.uuid "campagne_id"
+    t.uuid "situation_id"
     t.index ["campagne_id"], name: "index_situations_configurations_on_campagne_id"
     t.index ["situation_id"], name: "index_situations_configurations_on_situation_id"
   end
@@ -154,7 +157,9 @@ ActiveRecord::Schema.define(version: 2019_07_29_084304) do
   add_foreign_key "campagnes", "questionnaires"
   add_foreign_key "choix", "questions"
   add_foreign_key "evaluations", "campagnes"
+  add_foreign_key "evenements", "evaluations"
   add_foreign_key "evenements", "situations"
   add_foreign_key "questionnaires_questions", "questionnaires"
   add_foreign_key "questionnaires_questions", "questions"
+  add_foreign_key "situations_configurations", "campagnes"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -2,45 +2,45 @@
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
 #
-# Note that this schema.rb definition is the authoritative source for your
-# database schema. If you need to create the application database on another
-# system, you should be using db:schema:load, not running all the migrations
-# from scratch. The latter is a flawed and unsustainable approach (the more migrations
-# you'll amass, the slower it'll run and the greater likelihood for issues).
+# This file is the source Rails uses to define your schema when running `rails
+# db:schema:load`. When creating a new database, `rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_09_23_210147) do
+ActiveRecord::Schema.define(version: 2019_09_24_080332) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
 
-  create_table "active_admin_comments", force: :cascade do |t|
+  create_table "active_admin_comments", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "namespace"
     t.text "body"
     t.string "resource_type"
-    t.bigint "resource_id"
     t.string "author_type"
     t.bigint "author_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.uuid "resource_id"
     t.index ["author_type", "author_id"], name: "index_active_admin_comments_on_author_type_and_author_id"
     t.index ["namespace"], name: "index_active_admin_comments_on_namespace"
     t.index ["resource_type", "resource_id"], name: "index_active_admin_comments_on_resource_type_and_resource_id"
   end
 
-  create_table "active_storage_attachments", force: :cascade do |t|
+  create_table "active_storage_attachments", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
-    t.bigint "record_id", null: false
-    t.bigint "blob_id", null: false
     t.datetime "created_at", null: false
+    t.uuid "blob_id"
+    t.uuid "record_id"
     t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
     t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
   end
 
-  create_table "active_storage_blobs", force: :cascade do |t|
+  create_table "active_storage_blobs", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "key", null: false
     t.string "filename", null: false
     t.string "content_type"
@@ -95,7 +95,7 @@ ActiveRecord::Schema.define(version: 2019_09_23_210147) do
 
   create_table "evenements", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "nom"
-    t.jsonb "donnees", default: "{}", null: false
+    t.jsonb "donnees", default: {}, null: false
     t.datetime "date"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false

--- a/spec/features/campagne_spec.rb
+++ b/spec/features/campagne_spec.rb
@@ -13,7 +13,7 @@ describe 'Admin - Campagne', type: :feature do
     create :campagne, libelle: 'Rouen 30 mars', code: 'A5ROUEN', compte: compte_organisation
   end
   let!(:evaluation) { create :evaluation, campagne: campagne }
-  let(:derniere_campagne) { Campagne.order(created_at: :desc).first }
+  let(:derniere_campagne) { Campagne.last }
 
   describe 'index' do
     context 'en organisation' do

--- a/spec/features/campagne_spec.rb
+++ b/spec/features/campagne_spec.rb
@@ -4,14 +4,16 @@ require 'rails_helper'
 
 describe 'Admin - Campagne', type: :feature do
   let!(:compte_connecte) { se_connecter_comme_organisation }
+  let(:premier_compte) { Compte.order(created_at: :desc).last }
   let!(:ma_campagne) do
-    create :campagne, libelle: 'Amiens 18 juin', code: 'A5RC8', compte: Compte.first
+    create :campagne, libelle: 'Amiens 18 juin', code: 'A5RC8', compte: premier_compte
   end
   let(:compte_organisation) { create :compte_organisation, email: 'orga@eva.fr' }
   let!(:campagne) do
     create :campagne, libelle: 'Rouen 30 mars', code: 'A5ROUEN', compte: compte_organisation
   end
   let!(:evaluation) { create :evaluation, campagne: campagne }
+  let(:derniere_campagne) { Campagne.order(created_at: :desc).first }
 
   describe 'index' do
     context 'en organisation' do
@@ -61,8 +63,8 @@ describe 'Admin - Campagne', type: :feature do
 
         it do
           expect { click_on 'Créer' }.to(change { Campagne.count })
-          expect(Campagne.last.code).to be_present
-          expect(Campagne.last.compte).to eq compte_connecte
+          expect(derniere_campagne.code).to be_present
+          expect(derniere_campagne.compte).to eq compte_connecte
           expect(page).to have_content 'Mon QCM'
         end
 
@@ -70,7 +72,7 @@ describe 'Admin - Campagne', type: :feature do
           before { fill_in :campagne_code, with: 'EUROCKS' }
           it do
             expect { click_on 'Créer' }.to(change { Campagne.count })
-            expect(Campagne.last.code).to eq 'EUROCKS'
+            expect(derniere_campagne.code).to eq 'EUROCKS'
           end
         end
       end
@@ -78,7 +80,7 @@ describe 'Admin - Campagne', type: :feature do
 
     context 'en administrateur' do
       before do
-        Compte.first.update(role: 'administrateur')
+        premier_compte.update(role: 'administrateur')
         visit new_admin_campagne_path
         fill_in :campagne_libelle, with: 'Belfort, pack demandeur'
         fill_in :campagne_code, with: ''
@@ -88,7 +90,7 @@ describe 'Admin - Campagne', type: :feature do
 
       it do
         expect { click_on 'Créer' }.to(change { Campagne.count })
-        expect(Campagne.last.compte).to eq compte_organisation
+        expect(derniere_campagne.compte).to eq compte_organisation
       end
     end
   end
@@ -96,7 +98,7 @@ describe 'Admin - Campagne', type: :feature do
   describe 'show' do
     let(:situation) { create :situation_inventaire }
     before do
-      Compte.first.update(role: 'administrateur')
+      premier_compte.update(role: 'administrateur')
       campagne.situations_configurations.create! situation: situation
       visit admin_campagne_path campagne
     end

--- a/spec/features/campagne_spec.rb
+++ b/spec/features/campagne_spec.rb
@@ -4,16 +4,14 @@ require 'rails_helper'
 
 describe 'Admin - Campagne', type: :feature do
   let!(:compte_connecte) { se_connecter_comme_organisation }
-  let(:premier_compte) { Compte.order(created_at: :desc).last }
   let!(:ma_campagne) do
-    create :campagne, libelle: 'Amiens 18 juin', code: 'A5RC8', compte: premier_compte
+    create :campagne, libelle: 'Amiens 18 juin', code: 'A5RC8', compte: Compte.first
   end
   let(:compte_organisation) { create :compte_organisation, email: 'orga@eva.fr' }
   let!(:campagne) do
     create :campagne, libelle: 'Rouen 30 mars', code: 'A5ROUEN', compte: compte_organisation
   end
   let!(:evaluation) { create :evaluation, campagne: campagne }
-  let(:derniere_campagne) { Campagne.last }
 
   describe 'index' do
     context 'en organisation' do
@@ -63,8 +61,8 @@ describe 'Admin - Campagne', type: :feature do
 
         it do
           expect { click_on 'Créer' }.to(change { Campagne.count })
-          expect(derniere_campagne.code).to be_present
-          expect(derniere_campagne.compte).to eq compte_connecte
+          expect(Campagne.last.code).to be_present
+          expect(Campagne.last.compte).to eq compte_connecte
           expect(page).to have_content 'Mon QCM'
         end
 
@@ -72,7 +70,7 @@ describe 'Admin - Campagne', type: :feature do
           before { fill_in :campagne_code, with: 'EUROCKS' }
           it do
             expect { click_on 'Créer' }.to(change { Campagne.count })
-            expect(derniere_campagne.code).to eq 'EUROCKS'
+            expect(Campagne.last.code).to eq 'EUROCKS'
           end
         end
       end
@@ -80,7 +78,7 @@ describe 'Admin - Campagne', type: :feature do
 
     context 'en administrateur' do
       before do
-        premier_compte.update(role: 'administrateur')
+        Compte.first.update(role: 'administrateur')
         visit new_admin_campagne_path
         fill_in :campagne_libelle, with: 'Belfort, pack demandeur'
         fill_in :campagne_code, with: ''
@@ -90,7 +88,7 @@ describe 'Admin - Campagne', type: :feature do
 
       it do
         expect { click_on 'Créer' }.to(change { Campagne.count })
-        expect(derniere_campagne.compte).to eq compte_organisation
+        expect(Campagne.last.compte).to eq compte_organisation
       end
     end
   end
@@ -98,7 +96,7 @@ describe 'Admin - Campagne', type: :feature do
   describe 'show' do
     let(:situation) { create :situation_inventaire }
     before do
-      premier_compte.update(role: 'administrateur')
+      Compte.first.update(role: 'administrateur')
       campagne.situations_configurations.create! situation: situation
       visit admin_campagne_path campagne
     end

--- a/spec/features/evaluation_spec.rb
+++ b/spec/features/evaluation_spec.rb
@@ -9,9 +9,8 @@ describe 'Admin - Evaluation', type: :feature do
     let(:compte_rouen) { create :compte, role: 'organisation' }
     let(:campagne_rouen) { create :campagne, compte: compte_rouen, libelle: 'Rouen 2019' }
     let!(:evaluation) { create :evaluation, campagne: campagne_rouen }
-    let(:premier_compte) { Compte.first }
     let(:ma_campagne) do
-      create :campagne, compte: premier_compte, libelle: 'Paris 2019', code: 'paris2019'
+      create :campagne, compte: Compte.first, libelle: 'Paris 2019', code: 'paris2019'
     end
 
     let!(:mon_evaluation) { create :evaluation, campagne: ma_campagne, created_at: 3.days.ago }
@@ -30,7 +29,7 @@ describe 'Admin - Evaluation', type: :feature do
       end
     end
 
-    it 'Je ne vois que les évaluations liées à mes campagnes' do
+    it 'Trie les évaluations de la plus récentes à la plus vieille' do
       visit admin_evaluations_path
       within '.odd:first-of-type' do
         expect(page).to have_content 'Jean'

--- a/spec/features/evaluation_spec.rb
+++ b/spec/features/evaluation_spec.rb
@@ -9,7 +9,7 @@ describe 'Admin - Evaluation', type: :feature do
     let(:compte_rouen) { create :compte, role: 'organisation' }
     let(:campagne_rouen) { create :campagne, compte: compte_rouen, libelle: 'Rouen 2019' }
     let!(:evaluation) { create :evaluation, campagne: campagne_rouen }
-    let(:premier_compte) { Compte.order(created_at: :desc).last }
+    let(:premier_compte) { Compte.first }
     let(:ma_campagne) do
       create :campagne, compte: premier_compte, libelle: 'Paris 2019', code: 'paris2019'
     end

--- a/spec/features/evaluation_spec.rb
+++ b/spec/features/evaluation_spec.rb
@@ -9,11 +9,15 @@ describe 'Admin - Evaluation', type: :feature do
     let(:compte_rouen) { create :compte, role: 'organisation' }
     let(:campagne_rouen) { create :campagne, compte: compte_rouen, libelle: 'Rouen 2019' }
     let!(:evaluation) { create :evaluation, campagne: campagne_rouen }
-
+    let(:premier_compte) { Compte.order(created_at: :desc).last }
     let(:ma_campagne) do
-      create :campagne, compte: Compte.first, libelle: 'Paris 2019', code: 'paris2019'
+      create :campagne, compte: premier_compte, libelle: 'Paris 2019', code: 'paris2019'
     end
-    let!(:mon_evaluation) { create :evaluation, campagne: ma_campagne }
+
+    let!(:mon_evaluation) { create :evaluation, campagne: ma_campagne, created_at: 3.days.ago }
+    let!(:mon_evaluation2) do
+      create :evaluation, campagne: ma_campagne, created_at: DateTime.now, nom: 'Jean'
+    end
 
     it 'Je ne vois que les évaluations liées à mes campagnes' do
       visit admin_evaluations_path
@@ -23,6 +27,13 @@ describe 'Admin - Evaluation', type: :feature do
       within('#filters_sidebar_section') do
         expect(page).to have_content 'Paris 2019'
         expect(page).to_not have_content 'Rouen 2019'
+      end
+    end
+
+    it 'Je ne vois que les évaluations liées à mes campagnes' do
+      visit admin_evaluations_path
+      within '.odd:first-of-type' do
+        expect(page).to have_content 'Jean'
       end
     end
   end

--- a/spec/models/questionnaire_question_spec.rb
+++ b/spec/models/questionnaire_question_spec.rb
@@ -8,6 +8,6 @@ describe QuestionnaireQuestion do
 
     subject { described_class.new(question: question) }
 
-    it { should validate_uniqueness_of(:question_id).scoped_to(:questionnaire_id) }
+    it { should validate_uniqueness_of(:question_id).scoped_to(:questionnaire_id).case_insensitive }
   end
 end

--- a/spec/models/situation_configuration_spec.rb
+++ b/spec/models/situation_configuration_spec.rb
@@ -3,5 +3,5 @@
 require 'rails_helper'
 
 describe SituationConfiguration do
-  it { should validate_uniqueness_of(:situation_id).scoped_to(:campagne_id) }
+  it { should validate_uniqueness_of(:situation_id).scoped_to(:campagne_id).case_insensitive }
 end


### PR DESCRIPTION
contribue (voire fix?) #163 

Cette PR remplace les id des objets métier en uuid. Je la mets en draft car je souhaite jouer les migrations avec une base de données réelle avant de la fusionner dans master