### PR TITLE
Inverse le filtre de sélection de restitution.

### DIFF
--- a/app/admin/evaluation.rb
+++ b/app/admin/evaluation.rb
@@ -12,7 +12,10 @@ ActiveAdmin.register Evaluation do
   end
 
   action_item :pdf, only: :show, if: proc { restitution_globale.present? } do
-    link_to('Export PDF', { restitutions_ignorees: params[:restitutions_ignorees], format: :pdf },
+    link_to('Export PDF', {
+              restitutions_selectionnees: params[:restitutions_selectionnees],
+              format: :pdf
+            },
             target: '_blank')
   end
 
@@ -41,13 +44,16 @@ ActiveAdmin.register Evaluation do
       Evenement.where(nom: 'demarrage', evaluation_id: params[:id])
     end
 
-    def restitution_globale
-      restitutions_ignorees = params[:restitutions_ignorees] || []
-      restitution_ids = restitutions.collect { |r| r.id.to_s } - restitutions_ignorees
-      return if restitution_ids.blank?
+    def restitutions_selectionnees_ids
+      params[:restitutions_selectionnees] ||= restitutions.collect { |r| r.id.to_s }
+      params[:restitutions_selectionnees]
+    end
 
-      evaluation = Evenement.find(restitution_ids.first).evaluation
-      restitutions = restitution_ids.map do |id|
+    def restitution_globale
+      return if restitutions_selectionnees_ids.blank?
+
+      evaluation = Evenement.find(restitutions_selectionnees_ids.first).evaluation
+      restitutions = restitutions_selectionnees_ids.map do |id|
         FabriqueRestitution.depuis_evenement_id id
       end
       Restitution::Globale.new restitutions: restitutions, evaluation: evaluation

--- a/app/views/admin/evaluations/_show.html.arb
+++ b/app/views/admin/evaluations/_show.html.arb
@@ -3,9 +3,9 @@
 panel t('.titre.restitutions') do
   form method: :get do
     table_for restitutions do
-      column :ignorer do |evenement|
-        check_box_tag 'restitutions_ignorees[]', evenement.id,
-                      params[:restitutions_ignorees]&.include?(evenement.id.to_s)
+      column :selection do |evenement|
+        check_box_tag 'restitutions_selectionnees[]', evenement.id,
+                      params[:restitutions_selectionnees]&.include?(evenement.id.to_s)
       end
       column :situation
       column :session_id


### PR DESCRIPTION
Par défaut, toutes les restitutions sont sélectionnées. La déselection
supprime la restitution du rapport.

![Screenshot_2019-09-24 Roger Compétences Pro Serveur](https://user-images.githubusercontent.com/86659/65501600-8f8dcc80-dec1-11e9-83a3-d94fe775e5b4.png)
