### PR TITLE
Ignore les réponses sans réponse dans l'efficience des questions

### DIFF
--- a/app/models/restitution/questions.rb
+++ b/app/models/restitution/questions.rb
@@ -29,7 +29,9 @@ module Restitution
     end
 
     def efficience
-      question_qcm_repondue = questions_et_reponses.select { |q| q[:question].is_a?(QuestionQcm) }
+      question_qcm_repondue = questions_et_reponses.select do |q|
+        q[:question].is_a?(QuestionQcm) && q[:reponse].present?
+      end
       points_total = points_par_question(question_qcm_repondue).inject(0, :+)
       (points_total / nombre_questions_qcm.to_f) * 100.0
     end

--- a/spec/models/restitution/questions_spec.rb
+++ b/spec/models/restitution/questions_spec.rb
@@ -154,6 +154,13 @@ describe Restitution::Questions do
                        question_id: question2.id)
       end
 
+      let(:evenement_reponse_incomplet) do
+        create(:evenement_reponse,
+               evaluation: evaluation,
+               situation: situation,
+               donnees: { question: question2.id })
+      end
+
       it 'pour une mauvaise et une bonne réponse' do
         restitution = described_class.new(
           campagne, [
@@ -169,6 +176,16 @@ describe Restitution::Questions do
         restitution = described_class.new(
           campagne, [
             evenement_demarrage
+          ]
+        )
+        expect(restitution.efficience).to eq 0
+      end
+
+      it 'ignore les reponses incomplètes' do
+        restitution = described_class.new(
+          campagne, [
+            evenement_demarrage,
+            evenement_reponse_incomplet
           ]
         )
         expect(restitution.efficience).to eq 0


### PR DESCRIPTION
il y a 90 évenements réponses qui n'ont pas de réponse dans les données. Ils empêchent d'afficher la restitution, du coup cette PR les ignore arbitrairement.