### PR TITLE
Tri les évaluations dans la campagne par ordre antéchronologique

### DIFF
--- a/app/models/campagne.rb
+++ b/app/models/campagne.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Campagne < ApplicationRecord
-  has_many :evaluations
+  has_many :evaluations, -> { order(created_at: :desc) }
   has_many :situations_configurations, -> { order(position: :asc) }
   has_many :situations, through: :situations_configurations
   belongs_to :questionnaire, optional: true

--- a/spec/models/campagne_spec.rb
+++ b/spec/models/campagne_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe Campagne, type: :model do
   it { should validate_presence_of :libelle }
   it { should validate_uniqueness_of :code }
   it { should belong_to(:questionnaire).optional }
+  it { should have_many(:evaluations).order(created_at: :desc) }
 
   describe 'validation du code' do
     context 'garde le code initial' do


### PR DESCRIPTION
antéchronologique ça veut dire dans l'ordre inverse de la date de création.

Fix #171 