### PR TITLE
Ajoute des compteurs du nombre d'évaluations dans le dashboard.

### DIFF
--- a/app/admin/dashboard.rb
+++ b/app/admin/dashboard.rb
@@ -4,31 +4,29 @@ ActiveAdmin.register_page 'Dashboard' do
   menu priority: 1, label: proc { I18n.t('active_admin.dashboard') }
 
   content title: proc { I18n.t('active_admin.dashboard') } do
-    div class: 'blank_slate_container', id: 'dashboard_default_message' do
-      span class: 'blank_slate' do
-        span I18n.t('active_admin.dashboard_welcome.welcome')
-        small I18n.t('active_admin.dashboard_welcome.call_to_action')
-      end
-    end
+    campagnes = if current_compte.administrateur?
+                  Campagne.all
+                else
+                  Campagne.where(compte: current_compte)
+                end
 
-    # Here is an example of a simple dashboard with columns and panels.
-    #
-    # columns do
-    #   column do
-    #     panel "Recent Posts" do
-    #       ul do
-    #         Post.recent(5).map do |post|
-    #           li link_to(post.title, admin_post_path(post))
-    #         end
-    #       end
-    #     end
-    #   end
+    debut_aujourdhui = Date.current.beginning_of_day
+    interval_hier = Date.yesterday.beginning_of_day..debut_aujourdhui
+    nombre_evaluations_total = campagnes.sum(:nombre_evaluations)
+    nombre_evaluations_hier = campagnes
+                              .joins(:evaluations)
+                              .where('evaluations.created_at' => interval_hier)
+                              .count
+    nombre_evaluations_aujourdhui = campagnes
+                                    .joins(:evaluations)
+                                    .where('evaluations.created_at > ?', debut_aujourdhui)
+                                    .count
 
-    #   column do
-    #     panel "Info" do
-    #       para "Welcome to ActiveAdmin."
-    #     end
-    #   end
-    # end
+    render partial: 'dashboard',
+           locals: {
+             total: nombre_evaluations_total,
+             hier: nombre_evaluations_hier,
+             aujourdhui: nombre_evaluations_aujourdhui
+           }
   end
 end

--- a/app/assets/stylesheets/active_admin.scss
+++ b/app/assets/stylesheets/active_admin.scss
@@ -36,3 +36,17 @@
     background-color: gray;
   }
 }
+
+.compteurs {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  .compteur {
+    display: flex;
+    flex:1;
+    justify-content: center;
+    align-items: center;
+    flex-direction: column;
+  }
+}

--- a/app/views/admin/dashboard/_dashboard.html.arb
+++ b/app/views/admin/dashboard/_dashboard.html.arb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+panel t('.nombre_evaluations.titre') do
+  div class: 'compteurs' do
+    { hier: hier, aujourdhui: aujourdhui, total: total }.each do |clef, valeur|
+      div class: 'compteur' do
+        h1 valeur
+        span t(".nombre_evaluations.#{clef}")
+      end
+    end
+  end
+end

--- a/config/locales/views/dashboard.yml
+++ b/config/locales/views/dashboard.yml
@@ -1,0 +1,7 @@
+fr:
+  admin:
+    dashboard:
+      dashboard:
+        nombre_evaluations:
+          titre: Nombre d'évaluations
+          total: Total


### PR DESCRIPTION
Pour un aperçu rapide dès la connexion.

![Screenshot_2019-10-14 Tableau de bord Compétences Pro Serveur](https://user-images.githubusercontent.com/86659/66752654-31d21c00-ee92-11e9-92ab-1c3210345914.png)
