### PR TITLE
permet de comptabiliser les dangers identifiés avant l'activation de l'aide 1

### DIFF
--- a/app/views/admin/restitutions/_restitution_securite.html.arb
+++ b/app/views/admin/restitutions/_restitution_securite.html.arb
@@ -3,6 +3,7 @@
 panel t('.restitution_securite') do
   attributes_table_for restitution do
     row t('.dangers_identifies'), &:nombre_dangers_identifies
+    row t('.dangers_identifies_avant_aide_1'), &:nombre_dangers_identifies_avant_aide_1
     row t('.dangers_bien_qualifies'), &:nombre_bien_qualifies
     row t('.retours_dangers_deja_qualifies'), &:nombre_retours_deja_qualifies
   end

--- a/config/locales/views/evaluations.yml
+++ b/config/locales/views/evaluations.yml
@@ -101,3 +101,4 @@ fr:
         dangers_bien_qualifies: Dangers bien qualifiés
         dangers_identifies: Dangers identifiés
         retours_dangers_deja_qualifies: Retours sur les situations déjà qualifiées
+        dangers_identifies_avant_aide_1: Dangers identifiés avant activation de l'aide N°1

--- a/spec/factories/evenement.rb
+++ b/spec/factories/evenement.rb
@@ -71,5 +71,9 @@ FactoryBot.define do
     factory :evenement_identification_danger do
       nom { 'identificationDanger' }
     end
+
+    factory :activation_aide do
+      nom { 'activationAide' }
+    end
   end
 end

--- a/spec/models/restitution/securite_spec.rb
+++ b/spec/models/restitution/securite_spec.rb
@@ -102,4 +102,46 @@ describe Restitution::Securite do
       it { expect(restitution.nombre_retours_deja_qualifies).to eq 1 }
     end
   end
+
+  describe '#nombre_dangers_identifies_avant_aide_1' do
+    context 'sans évenement' do
+      let(:evenements) { [] }
+      it { expect(restitution.nombre_dangers_identifies_avant_aide_1).to eq 0 }
+    end
+
+    context "avec des dangers identifiés en ayant activé l'aide" do
+      let(:evenements) do
+        [build(:evenement_identification_danger,
+               donnees: { reponse: 'oui', danger: 'danger', nom: 'avant' },
+               date: 3.minutes.ago),
+         build(:evenement_identification_danger,
+               donnees: { reponse: 'oui', danger: 'danger', nom: 'avant' },
+               date: 2.minutes.ago),
+         build(:activation_aide),
+         build(:evenement_identification_danger,
+               donnees: { reponse: 'oui', danger: 'danger' },
+               date: 2.minutes.from_now)]
+      end
+      it { expect(restitution.nombre_dangers_identifies_avant_aide_1).to eq 2 }
+    end
+
+    context "avec des dangers identifiés aprés avoir activé l'aide" do
+      let(:evenements) do
+        [build(:activation_aide),
+         build(:evenement_identification_danger,
+               donnees: { reponse: 'oui', danger: 'danger' },
+               date: 2.minutes.from_now)]
+      end
+      it { expect(restitution.nombre_dangers_identifies_avant_aide_1).to eq 0 }
+    end
+
+    context "avec un danger identifié sans avoir activé l'aide" do
+      let(:evenements) do
+        [build(:evenement_identification_danger,
+               donnees: { reponse: 'oui', danger: 'danger' },
+               date: 2.minutes.from_now)]
+      end
+      it { expect(restitution.nombre_dangers_identifies_avant_aide_1).to eq 1 }
+    end
+  end
 end


### PR DESCRIPTION
 Affiche également le résultat dans le BO.

contribue à la #184 
