### PR TITLE
Mesure le temps d'identification de chaque danger pour la situation s…

### DIFF
--- a/app/models/restitution/securite.rb
+++ b/app/models/restitution/securite.rb
@@ -66,9 +66,9 @@ module Restitution
         end
     end
 
-    def temps_identifications_dangers
+    def temps_ouvertures_zones_dangers
       les_temps = []
-      evenements_pour_mesurer_temps_identifications.each_slice(2) do |e1, e2|
+      evenements_demarrage_ouvertures_et_qualifications.each_slice(2) do |e1, e2|
         next if e2.blank?
 
         les_temps << e2.date - e1.date
@@ -106,14 +106,14 @@ module Restitution
       )
     end
 
-    def evenements_pour_mesurer_temps_identifications
+    def evenements_demarrage_ouvertures_et_qualifications
       dernier_evenement_retenu = nil
       evenements_situation.select do |e|
         next if dernier_evenement_retenu&.nom == e.nom
 
         selectionne = [AvecEntrainement::EVENEMENT[:DEMARRAGE],
                        EVENEMENT[:QUALIFICATION_DANGER]].include?(e.nom) ||
-                      e.nom == EVENEMENT[:IDENTIFICATION_DANGER] && e.donnees['danger'].present?
+                      e.nom == EVENEMENT[:OUVERTURE_ZONE] && e.donnees['danger'].present?
         dernier_evenement_retenu = e if selectionne
         selectionne
       end

--- a/app/views/admin/restitutions/_restitution_securite.html.arb
+++ b/app/views/admin/restitutions/_restitution_securite.html.arb
@@ -9,8 +9,10 @@ panel t('.restitution_securite') do
     row t('.dangers_identifies_avant_aide_1'), &:nombre_dangers_identifies_avant_aide_1
     row t('.dangers_bien_qualifies'), &:nombre_bien_qualifies
     row t('.retours_dangers_deja_qualifies'), &:nombre_retours_deja_qualifies
-    row t('.temps_identification_premier_danger') do |r|
-      Time.at(r.temps_identification_premier_danger).strftime('%M:%S')
+    row t('.temps_identifications_dangers') do |r|
+      r.temps_identifications_dangers.collect do |temps|
+        Time.at(temps).strftime('%M:%S')
+      end.join(', ')
     end
     row t('.attention_visuo_spatiale') do |restitution|
       t(restitution.attention_visuo_spatiale, scope: 'admin.evaluations.restitution_competence')

--- a/app/views/admin/restitutions/_restitution_securite.html.arb
+++ b/app/views/admin/restitutions/_restitution_securite.html.arb
@@ -9,8 +9,8 @@ panel t('.restitution_securite') do
     row t('.dangers_identifies_avant_aide_1'), &:nombre_dangers_identifies_avant_aide_1
     row t('.dangers_bien_qualifies'), &:nombre_bien_qualifies
     row t('.retours_dangers_deja_qualifies'), &:nombre_retours_deja_qualifies
-    row t('.temps_identifications_dangers') do |r|
-      r.temps_identifications_dangers.collect do |temps|
+    row t('.temps_ouvertures_zones_dangers') do |r|
+      r.temps_ouvertures_zones_dangers.collect do |temps|
         Time.at(temps).strftime('%M:%S')
       end.join(', ')
     end

--- a/config/locales/views/evaluations.yml
+++ b/config/locales/views/evaluations.yml
@@ -107,5 +107,5 @@ fr:
         retours_dangers_deja_qualifies: Retours sur les situations déjà qualifiées
         retours_zones_sans_danger: Retours sur les zones sans danger
         dangers_identifies_avant_aide_1: Dangers identifiés avant activation de l'aide N°1
-        temps_identifications_dangers: Temps d'identification des dangers
+        temps_ouvertures_zones_dangers: Temps d'ouvertures de zones de danger
         attention_visuo_spatiale: Attention visuo-spatiale

--- a/config/locales/views/evaluations.yml
+++ b/config/locales/views/evaluations.yml
@@ -107,5 +107,5 @@ fr:
         retours_dangers_deja_qualifies: Retours sur les situations déjà qualifiées
         retours_zones_sans_danger: Retours sur les zones sans danger
         dangers_identifies_avant_aide_1: Dangers identifiés avant activation de l'aide N°1
-        temps_identification_premier_danger: Temps premier danger identifié
+        temps_identifications_dangers: Temps d'identification des dangers
         attention_visuo_spatiale: Attention visuo-spatiale

--- a/spec/models/restitution/securite_spec.rb
+++ b/spec/models/restitution/securite_spec.rb
@@ -165,65 +165,65 @@ describe Restitution::Securite do
     end
   end
 
-  describe '#temps_identifications_dangers' do
-    context 'sans danger identifié' do
+  describe '#temps_ouvertures_zones_dangers' do
+    context 'sans zone danger ouverte' do
       let(:evenements) { [] }
-      it { expect(restitution.temps_identifications_dangers).to eq [] }
+      it { expect(restitution.temps_ouvertures_zones_dangers).to eq [] }
     end
 
-    context 'un danger identifié' do
+    context 'une zone danger ouverte' do
       let(:evenements) do
         [build(:evenement_demarrage, date: Time.local(2019, 10, 9, 10, 0)),
-         build(:evenement_identification_danger,
-               donnees: { reponse: 'non', danger: 'danger' }, date: Time.local(2019, 10, 9, 10, 1))]
+         build(:evenement_ouverture_zone,
+               donnees: { danger: 'danger' }, date: Time.local(2019, 10, 9, 10, 1))]
       end
-      it { expect(restitution.temps_identifications_dangers).to eq [60] }
+      it { expect(restitution.temps_ouvertures_zones_dangers).to eq [60] }
     end
 
-    context 'deux danger identifiés' do
+    context 'deux zone danger ouverts' do
       let(:evenements) do
         [build(:evenement_demarrage, date: Time.local(2019, 10, 9, 10, 0)),
-         build(:evenement_identification_danger,
-               donnees: { reponse: 'non', danger: 'danger' }, date: Time.local(2019, 10, 9, 10, 1)),
+         build(:evenement_ouverture_zone,
+               donnees: { danger: 'danger' }, date: Time.local(2019, 10, 9, 10, 1)),
          build(:evenement_qualification_danger, date: Time.local(2019, 10, 9, 10, 2)),
-         build(:evenement_identification_danger,
-               donnees: { reponse: 'non', danger: 'd2' }, date: Time.local(2019, 10, 9, 10, 4))]
+         build(:evenement_ouverture_zone,
+               donnees: { danger: 'd2' }, date: Time.local(2019, 10, 9, 10, 4))]
       end
-      it { expect(restitution.temps_identifications_dangers).to eq [60, 120] }
+      it { expect(restitution.temps_ouvertures_zones_dangers).to eq [60, 120] }
     end
 
-    context 'ignore les non dangers identifiés' do
+    context 'ignore les zones non dangers ouverts' do
       let(:evenements) do
         [build(:evenement_demarrage, date: Time.local(2019, 10, 9, 10, 0)),
-         build(:evenement_identification_danger,
-               donnees: { reponse: 'non' }, date: Time.local(2019, 10, 9, 10, 1)),
-         build(:evenement_identification_danger,
-               donnees: { reponse: 'oui', danger: 'danger' }, date: Time.local(2019, 10, 9, 10, 3))]
+         build(:evenement_ouverture_zone,
+               donnees: {}, date: Time.local(2019, 10, 9, 10, 1)),
+         build(:evenement_ouverture_zone,
+               donnees: { danger: 'danger' }, date: Time.local(2019, 10, 9, 10, 3))]
       end
-      it { expect(restitution.temps_identifications_dangers).to eq [180] }
+      it { expect(restitution.temps_ouvertures_zones_dangers).to eq [180] }
     end
 
     context 'quand on ne finit pas par une identification' do
       let(:evenements) do
         [build(:evenement_demarrage, date: Time.local(2019, 10, 9, 10, 0)),
-         build(:evenement_identification_danger,
-               donnees: { reponse: 'non', danger: 'danger' }, date: Time.local(2019, 10, 9, 10, 1)),
+         build(:evenement_ouverture_zone,
+               donnees: { danger: 'danger' }, date: Time.local(2019, 10, 9, 10, 1)),
          build(:evenement_qualification_danger, date: Time.local(2019, 10, 9, 10, 2))]
       end
-      it { expect(restitution.temps_identifications_dangers).to eq [60] }
+      it { expect(restitution.temps_ouvertures_zones_dangers).to eq [60] }
     end
 
     context 'ignore les requalifications' do
       let(:evenements) do
         [build(:evenement_demarrage, date: Time.local(2019, 10, 9, 10, 0)),
-         build(:evenement_identification_danger,
-               donnees: { reponse: 'non', danger: 'danger' }, date: Time.local(2019, 10, 9, 10, 1)),
+         build(:evenement_ouverture_zone,
+               donnees: { danger: 'danger' }, date: Time.local(2019, 10, 9, 10, 1)),
          build(:evenement_qualification_danger, date: Time.local(2019, 10, 9, 10, 2)),
          build(:evenement_qualification_danger, date: Time.local(2019, 10, 9, 10, 3)),
-         build(:evenement_identification_danger,
-               donnees: { reponse: 'non', danger: 'd2' }, date: Time.local(2019, 10, 9, 10, 5))]
+         build(:evenement_ouverture_zone,
+               donnees: { danger: 'd2' }, date: Time.local(2019, 10, 9, 10, 5))]
       end
-      it { expect(restitution.temps_identifications_dangers).to eq [60, 180] }
+      it { expect(restitution.temps_ouvertures_zones_dangers).to eq [60, 180] }
     end
   end
 


### PR DESCRIPTION
…écurité

Remplace l'identification du 1er danger par une liste de temps.

Contribue à #184 

![Capture d’écran 2019-10-23 à 13 39 46](https://user-images.githubusercontent.com/28393/67389312-a72ca380-f59a-11e9-90e6-98264be09987.png)
