### PR TITLE
Renomme les compétences fortes en compétences mobilisées lors de la m…

### DIFF
--- a/app/controllers/api/evaluations_controller.rb
+++ b/app/controllers/api/evaluations_controller.rb
@@ -19,7 +19,8 @@ module Api
       evaluation = Evaluation.find(params[:id])
       situations = evaluation.campagne.situations
       questions = evaluation.campagne.questionnaire&.questions || []
-      competences = FabriqueRestitution.restitution_globale(evaluation).competences_fortes
+      competences = FabriqueRestitution.restitution_globale(evaluation)
+                                       .competences_meilleure_restitution
       render json: { questions: questions, situations: situations, competences_fortes: competences }
     end
   end

--- a/app/models/restitution/globale.rb
+++ b/app/models/restitution/globale.rb
@@ -28,7 +28,7 @@ module Restitution
       efficiences.inject(0.0) { |somme, efficience| somme + efficience } / efficiences.size
     end
 
-    def competences_fortes
+    def competences_meilleure_restitution
       meilleure_restitution&.competences_mobilisees || []
     end
 

--- a/app/views/admin/evaluations/_show.html.arb
+++ b/app/views/admin/evaluations/_show.html.arb
@@ -22,9 +22,9 @@ panel t('.titre.restitutions') do
   end
 end
 if restitution_globale.present?
-  panel t('.titre.competences_fortes') do
+  panel t('.titre.competences_meilleure_restitution') do
     ul do
-      restitution_globale.competences_fortes.each do |competence|
+      restitution_globale.competences_meilleure_restitution.each do |competence|
         li t("admin.restitutions.restitution_competences.#{competence}")
       end
     end

--- a/config/locales/views/evaluations.yml
+++ b/config/locales/views/evaluations.yml
@@ -55,7 +55,7 @@ fr:
           description: Capacité à faire bien du premier coup, et à être constant dans la tâche à réaliser.
       show:
         titre:
-          competences_fortes: Compétences fortes
+          competences_meilleure_restitution: Compétences mobilisées dans la meilleure restitution
           restitution_globale: Restitution globale
           restitutions: Restitutions
     restitutions:

--- a/spec/models/restitution/globale_spec.rb
+++ b/spec/models/restitution/globale_spec.rb
@@ -108,10 +108,10 @@ describe Restitution::Globale do
     end
   end
 
-  describe '#competences_fortes' do
+  describe '#competences_meilleure_restitution' do
     context 'sans meilleure restitution' do
       let(:restitutions) { [] }
-      it { expect(restitution_globale.competences_fortes). to eq [] }
+      it { expect(restitution_globale.competences_meilleure_restitution). to eq [] }
     end
 
     context 'avec une meilleure restitution' do
@@ -119,7 +119,9 @@ describe Restitution::Globale do
       let(:restitutions) do
         [une_restitution(efficience: 20, competences_mobilisees: competences_mobilisees)]
       end
-      it { expect(restitution_globale.competences_fortes).to eq competences_mobilisees }
+      it do
+        expect(restitution_globale.competences_meilleure_restitution).to eq competences_mobilisees
+      end
     end
   end
 end


### PR DESCRIPTION
…eilleure restitution

Préparer le retour du tri des compétences. Du coup j'ai choisi de garder cette information et de la rendre plus explicite pour l'utilisateur

![Capture d’écran 2019-11-04 à 11 58 09](https://user-images.githubusercontent.com/28393/68116181-7cc3da00-fefa-11e9-991e-704022fe2da1.png)
