### PR TITLE
Ignore les compétences qui ne servent pas pour l'efficience dans les …

### DIFF
--- a/app/models/restitution/base.rb
+++ b/app/models/restitution/base.rb
@@ -14,6 +14,11 @@ module Restitution
       ::Competence::NIVEAU_1 => 25
     }.freeze
 
+    COMPETENCES_INUTILES_POUR_EFFICIENCE = [
+      ::Competence::PERSEVERANCE,
+      ::Competence::COMPREHENSION_CONSIGNE
+    ].freeze
+
     attr_reader :campagne, :evenements
     delegate :session_id, :situation, :date, to: :premier_evenement
 
@@ -65,10 +70,7 @@ module Restitution
     end
 
     def efficience
-      competences_utilisees = competences.except(
-        ::Competence::PERSEVERANCE,
-        ::Competence::COMPREHENSION_CONSIGNE
-      )
+      competences_utilisees = competences.except(*COMPETENCES_INUTILES_POUR_EFFICIENCE)
       return ::Competence::NIVEAU_INDETERMINE if competences_indeterminees?(competences_utilisees)
       return 0 if competences_utilisees.size.zero?
 

--- a/app/models/restitution/globale.rb
+++ b/app/models/restitution/globale.rb
@@ -48,16 +48,20 @@ module Restitution
     private
 
     def extraie_competences_depuis_restitutions
-      competences_max = @restitutions.each_with_object({}) do |restitution, memo|
+      competences_max.each_with_object([]) do |(competence, niveau), memo|
+        memo << { competence => niveau }
+      end
+    end
+
+    def competences_max
+      @restitutions.each_with_object({}) do |restitution, memo|
         restitution.competences.each do |competence, niveau|
-          next if niveau == NIVEAU_INDETERMINE
+          next if niveau == NIVEAU_INDETERMINE ||
+                  Base::COMPETENCES_INUTILES_POUR_EFFICIENCE.include?(competence)
 
           memo[competence] = niveau if (memo[competence] || 0) < niveau
         end
         memo
-      end
-      competences_max.each_with_object([]) do |(competence, niveau), memo|
-        memo << { competence => niveau }
       end
     end
   end

--- a/spec/models/restitution/globale_spec.rb
+++ b/spec/models/restitution/globale_spec.rb
@@ -9,7 +9,7 @@ describe Restitution::Globale do
   end
   let(:evaluation) { double }
 
-  def une_restitution(nom: nil, efficience: nil, competences_mobilisees: [Competence::PERSEVERANCE])
+  def une_restitution(nom: nil, efficience: nil, competences_mobilisees: [Competence::RAPIDITE])
     double(nom, efficience: efficience, competences_mobilisees: competences_mobilisees)
   end
 
@@ -126,7 +126,7 @@ describe Restitution::Globale do
   end
 
   describe '#competences_identifiees retournes les compétences consolidées par niveau' do
-    let(:niveau_perseverance) { { Competence::PERSEVERANCE => Competence::NIVEAU_4 } }
+    let(:niveau_comparaison) { { Competence::COMPARAISON_TRI => Competence::NIVEAU_4 } }
     let(:niveau_rapidite) { { Competence::RAPIDITE => Competence::NIVEAU_4 } }
 
     context 'aucune évaluation' do
@@ -135,42 +135,48 @@ describe Restitution::Globale do
     end
 
     context 'une évaluation, une compétences' do
-      let(:restitutions) { [double(competences: niveau_perseverance)] }
-      it { expect(restitution_globale.competences).to eq([niveau_perseverance]) }
+      let(:restitutions) { [double(competences: niveau_comparaison)] }
+      it { expect(restitution_globale.competences).to eq([niveau_comparaison]) }
     end
 
     context 'une évaluation, deux compétences' do
-      let(:restitutions) { [double(competences: niveau_perseverance.merge(niveau_rapidite))] }
-      it { expect(restitution_globale.competences).to eq([niveau_perseverance, niveau_rapidite]) }
+      let(:restitutions) { [double(competences: niveau_comparaison.merge(niveau_rapidite))] }
+      it { expect(restitution_globale.competences).to eq([niveau_comparaison, niveau_rapidite]) }
     end
 
     context 'deux évaluation, deux compétences différentes' do
-      let(:restitution1) { double(competences: niveau_perseverance) }
+      let(:restitution1) { double(competences: niveau_comparaison) }
       let(:restitution2) { double(competences: niveau_rapidite) }
       let(:restitutions) { [restitution1, restitution2] }
-      it { expect(restitution_globale.competences).to eq([niveau_perseverance, niveau_rapidite]) }
+      it { expect(restitution_globale.competences).to eq([niveau_comparaison, niveau_rapidite]) }
     end
 
     context 'retourne les niveaux les plus forts en premier' do
       let(:niveau_faible) { { Competence::ORGANISATION_METHODE => Competence::NIVEAU_1 } }
       let(:restitution1) { double(competences: niveau_faible) }
-      let(:restitution2) { double(competences: niveau_perseverance) }
+      let(:restitution2) { double(competences: niveau_comparaison) }
       let(:restitutions) { [restitution1, restitution2] }
-      it { expect(restitution_globale.competences).to eq([niveau_perseverance, niveau_faible]) }
+      it { expect(restitution_globale.competences).to eq([niveau_comparaison, niveau_faible]) }
     end
 
     context 'ignore les niveaux indéterminées' do
-      let(:niveau_indetermine) { { Competence::PERSEVERANCE => Competence::NIVEAU_INDETERMINE } }
+      let(:niveau_indetermine) { { Competence::COMPARAISON_TRI => Competence::NIVEAU_INDETERMINE } }
       let(:restitutions) { [double(competences: niveau_indetermine)] }
       it { expect(restitution_globale.competences).to eq([]) }
     end
 
     context 'retire les doublons' do
-      let(:niveau_perseverance_3) { { Competence::PERSEVERANCE => Competence::NIVEAU_3 } }
-      let(:restitution1) { double(competences: niveau_perseverance) }
-      let(:restitution2) { double(competences: niveau_perseverance_3) }
+      let(:niveau_comparaison_3) { { Competence::COMPARAISON_TRI => Competence::NIVEAU_3 } }
+      let(:restitution1) { double(competences: niveau_comparaison) }
+      let(:restitution2) { double(competences: niveau_comparaison_3) }
       let(:restitutions) { [restitution1, restitution2] }
-      it { expect(restitution_globale.competences).to eq([niveau_perseverance]) }
+      it { expect(restitution_globale.competences).to eq([niveau_comparaison]) }
+    end
+
+    context "ignore les compétences inutilisées dans l'efficience" do
+      let(:niveau_perseverance) { { Competence::PERSEVERANCE => Competence::NIVEAU_3 } }
+      let(:restitutions) { [double(competences: niveau_perseverance)] }
+      it { expect(restitution_globale.competences).to eq([]) }
     end
   end
 end


### PR DESCRIPTION
…compétences triées

contribue à #201 

Ignore Compréhension de Consigne et persévérence. Ce sont les mêmes compétences exclues pour le calcul de l'efficience, du coup j'en ai extrais une  configuration, sous forme de constante.

