### PR TITLE
Permet aux administrateurs de modifier toutes les évaluations

### DIFF
--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -28,6 +28,7 @@ class Ability
   end
 
   def droit_evenement(compte)
+    cannot %i[update create], Evenement
     cannot :read, Evenement unless compte.administrateur?
     can :read, Evenement, evaluation: { campagne: { compte_id: compte.id } }
   end
@@ -52,7 +53,5 @@ class Ability
 
   def droits_generiques
     can :manage, :all
-    cannot %i[destroy create], Evaluation
-    cannot %i[update create], Evenement
   end
 end

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'cancan/matchers'
+
+describe Ability do
+  subject(:ability) { Ability.new(compte) }
+
+  context 'Compte administrateur' do
+    let(:compte) { build :compte, role: 'administrateur' }
+
+    it { is_expected.to be_able_to(:manage, :all) }
+    it { is_expected.to be_able_to(%i[destroy create], Evaluation.new) }
+    it { is_expected.to_not be_able_to(:create, Evenement.new) }
+    it { is_expected.to be_able_to(:read, Evenement.new) }
+    it { is_expected.to be_able_to(:manage, Campagne.new) }
+    it { is_expected.to be_able_to(:manage, Questionnaire.new) }
+  end
+
+  context 'Compte organisation' do
+    let(:compte) { build :compte, role: 'organisation' }
+
+    it { is_expected.to_not be_able_to(:manage, Compte.new) }
+    it { is_expected.to_not be_able_to(%i[destroy create update], Situation.new) }
+    it { is_expected.to_not be_able_to(%i[destroy create update], Question.new) }
+    it { is_expected.to_not be_able_to(:manage, Questionnaire.new) }
+    it { is_expected.to be_able_to(:read, Questionnaire.new) }
+  end
+end

--- a/spec/models/compte_spec.rb
+++ b/spec/models/compte_spec.rb
@@ -13,7 +13,7 @@ describe Compte do
       let(:compte) { build :compte, role: 'administrateur' }
 
       it { is_expected.to be_able_to(:manage, :all) }
-      it { is_expected.to_not be_able_to(%i[destroy create], Evaluation.new) }
+      it { is_expected.to be_able_to(%i[destroy create], Evaluation.new) }
       it { is_expected.to_not be_able_to(:create, Evenement.new) }
       it { is_expected.to be_able_to(:read, Evenement.new) }
       it { is_expected.to be_able_to(:manage, Campagne.new) }

--- a/spec/models/compte_spec.rb
+++ b/spec/models/compte_spec.rb
@@ -5,29 +5,4 @@ require 'cancan/matchers'
 
 describe Compte do
   it { should validate_inclusion_of(:role).in_array(%w[administrateur organisation]) }
-
-  describe 'Gestion des droits' do
-    subject(:ability) { Ability.new(compte) }
-
-    context 'Compte administrateur' do
-      let(:compte) { build :compte, role: 'administrateur' }
-
-      it { is_expected.to be_able_to(:manage, :all) }
-      it { is_expected.to be_able_to(%i[destroy create], Evaluation.new) }
-      it { is_expected.to_not be_able_to(:create, Evenement.new) }
-      it { is_expected.to be_able_to(:read, Evenement.new) }
-      it { is_expected.to be_able_to(:manage, Campagne.new) }
-      it { is_expected.to be_able_to(:manage, Questionnaire.new) }
-    end
-
-    context 'Compte organisation' do
-      let(:compte) { build :compte, role: 'organisation' }
-
-      it { is_expected.to_not be_able_to(:manage, Compte.new) }
-      it { is_expected.to_not be_able_to(%i[destroy create update], Situation.new) }
-      it { is_expected.to_not be_able_to(%i[destroy create update], Question.new) }
-      it { is_expected.to_not be_able_to(:manage, Questionnaire.new) }
-      it { is_expected.to be_able_to(:read, Questionnaire.new) }
-    end
-  end
 end


### PR DESCRIPTION
Entre autre, l'idée c'est que les administrateurs puissent supprimer les évaluations de campagne dont ils ne sont pas propriétaire.

Fix #210 