### PR TITLE
Redirige l'index de l'API vers activeadmin.

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,8 @@ Rails.application.routes.draw do
   devise_for :comptes, ActiveAdmin::Devise.config
   ActiveAdmin.routes(self)
 
+  get '/', to: redirect('/admin')
+
   namespace :api do
     resources :evaluations, only: [:create, :show]
     resources :evenements

--- a/spec/features/index_spec.rb
+++ b/spec/features/index_spec.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe 'Index', type: :feature do
+  it 'Redirige vers activeadmin' do
+    visit '/'
+    expect(page.current_url).to eql('http://www.example.com/admin/login')
+  end
+end


### PR DESCRIPTION
Cela simplifie la vie des utilisateur·rice·s de l'admin.