### PR TITLE
Corrige la traduction des compétences dans les restitutions des évaluations

### DIFF
--- a/app/views/admin/restitutions/_restitution_competences.html.arb
+++ b/app/views/admin/restitutions/_restitution_competences.html.arb
@@ -3,7 +3,8 @@
 panel t('.titre') do
   attributes_table_for restitution do
     restitution.competences.each do |competence, niveau|
-      row(t(".#{competence}")) { niveau }
+      row(t("#{competence}.nom",
+            scope: 'admin.evaluations.restitution_competence')) { niveau }
     end
     row(t('.efficience')) { formate_efficience(restitution.efficience) }
   end

--- a/config/locales/views/evaluations.yml
+++ b/config/locales/views/evaluations.yml
@@ -77,6 +77,9 @@ fr:
         echec: Échec
         termine: Terminé
         indetermine: Indéterminée car abandon
+      restitution_competences:
+        titre: Évaluation des compétences
+        efficience: Efficience
       restitution_inventaire:
         ouverture_contenant: Ouvertures de contenant
         essai: Essai %{count}


### PR DESCRIPTION
J'ai corrigé en ajoutant une variable `scope_traduction`. J'espère recevoir une relecture ici par des personnes qui savent comment il faut faire les choses dans cette situation.