### PR TITLE
Corrige le rendu du PDF

### DIFF
--- a/app/views/layouts/pdf.pdf.erb
+++ b/app/views/layouts/pdf.pdf.erb
@@ -1,10 +1,10 @@
 <!DOCTYPE html>
 <html>
 <head>
-  <title>Restitution Compétences Pro</title>
+  <title>Restitution eva</title>
   <meta charset="utf-8">
   <meta http-equiv="x-ua-compatible" content="ie=edge">
-  <meta name="description" content="Restitution Compétences Pro">
+  <meta name="description" content="Restitution eva">
   <meta name="viewport" content="width=device-width, initial-scale=1">
 
   <%= stylesheet_link_tag wicked_pdf_asset_base64 "restitution_globale/restitution_globale_pdf" -%>

--- a/app/views/layouts/pdf.pdf.erb
+++ b/app/views/layouts/pdf.pdf.erb
@@ -6,8 +6,6 @@
   <meta http-equiv="x-ua-compatible" content="ie=edge">
   <meta name="description" content="Restitution eva">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-
-  <%= stylesheet_link_tag wicked_pdf_asset_base64 "restitution_globale/restitution_globale_pdf" -%>
 </head>
 
 <body>

--- a/app/views/layouts/pdf.pdf.erb
+++ b/app/views/layouts/pdf.pdf.erb
@@ -11,3 +11,4 @@
 <body>
   <%= yield %>
 </body>
+</html>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -35,7 +35,6 @@ Rails.application.configure do
 
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log
-  config.assets.precompile += %w[active_admin.css active_admin.js]
 
   # Raise an error on page load if there are pending migrations.
   config.active_record.migration_error = :page_load

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -38,7 +38,6 @@ Rails.application.configure do
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
   # config.force_ssl = true
-  config.assets.precompile += %w[active_admin.css active_admin.js]
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -1,0 +1,1 @@
+Rails.application.config.assets.precompile += %w[active_admin.css active_admin.js]

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -1,1 +1,1 @@
-Rails.application.config.assets.precompile += %w[active_admin.css active_admin.js]
+Rails.application.config.assets.precompile += %w[active_admin.css active_admin.js restitution_globale/restitution_globale_pdf.css]


### PR DESCRIPTION
Le rendu du PDF est cassé car la feuille de style n'était pas précompilé.

J'en ai profité pour nettoyer le layout avec le nom du produit et quelques petites choses.