### PR TITLE
Envoie le nom et la description des compétences au client

### DIFF
--- a/app/controllers/api/evaluations_controller.rb
+++ b/app/controllers/api/evaluations_controller.rb
@@ -22,7 +22,8 @@ module Api
           nom: I18n.t("#{identifiant}.nom",
                       scope: 'admin.evaluations.restitution_competence'),
           description: I18n.t("#{identifiant}.description",
-                              scope: 'admin.evaluations.restitution_competence')
+                              scope: 'admin.evaluations.restitution_competence'),
+          picto: ActionController::Base.helpers.asset_path(identifiant)
         }
       end
     end

--- a/app/controllers/api/evaluations_controller.rb
+++ b/app/controllers/api/evaluations_controller.rb
@@ -15,11 +15,25 @@ module Api
       end
     end
 
+    def map_descriptions(competences)
+      competences.map do |identifiant|
+        {
+          id: identifiant,
+          nom: I18n.t("#{identifiant}.nom",
+                      scope: 'admin.evaluations.restitution_competence'),
+          description: I18n.t("#{identifiant}.description",
+                              scope: 'admin.evaluations.restitution_competence')
+        }
+      end
+    end
+
     def show
       evaluation = Evaluation.find(params[:id])
       situations = evaluation.campagne.situations
       questions = evaluation.campagne.questionnaire&.questions || []
-      competences = FabriqueRestitution.restitution_globale(evaluation).competences
+      competences = map_descriptions(FabriqueRestitution
+        .restitution_globale(evaluation)
+        .competences)
       render json: { questions: questions, situations: situations, competences_fortes: competences }
     end
   end

--- a/app/controllers/api/evaluations_controller.rb
+++ b/app/controllers/api/evaluations_controller.rb
@@ -23,7 +23,7 @@ module Api
                       scope: 'admin.evaluations.restitution_competence'),
           description: I18n.t("#{identifiant}.description",
                               scope: 'admin.evaluations.restitution_competence'),
-          picto: ActionController::Base.helpers.asset_path(identifiant)
+          picto: ActionController::Base.helpers.asset_url(identifiant)
         }
       end
     end

--- a/config/application.rb
+++ b/config/application.rb
@@ -40,6 +40,7 @@ module CompetencesProServeur
       g.orm :active_record, foreign_key_type: :uuid
     end
 
+    config.action_controller.asset_host = "#{ENV['PROTOCOLE_SERVEUR']}://#{ENV['HOTE_SERVEUR']}"
     Rails.application.routes.default_url_options = {
       host: ENV['HOTE_SERVEUR'],
       protocol: ENV['PROTOCOLE_SERVEUR']

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -13,6 +13,7 @@ Rails.application.configure do
   # preloads Rails for running tests, you may have to set it to true.
   config.eager_load = false
 
+  config.action_controller.asset_host = "http://asset_host:port"
   Rails.application.routes.default_url_options = {
     host: 'test'
   }

--- a/spec/requests/evaluations_spec.rb
+++ b/spec/requests/evaluations_spec.rb
@@ -86,12 +86,18 @@ describe 'Evaluation API', type: :request do
             .to eql(attendues)
         end
 
-        it 'envoie aussi la descriptions des compétences' do
+        it 'envoie aussi le nom et la description des compétences' do
           premiere_competence = JSON.parse(response.body)['competences_fortes'][0]
           expect(premiere_competence['nom']).to eql("Vitesse d'exécution")
           expect(premiere_competence['description'])
             .to eql(I18n.t("#{Competence::RAPIDITE}.description",
                            scope: 'admin.evaluations.restitution_competence'))
+        end
+
+        it "envoie aussi l'URL du picto des compétences" do
+          premiere_competence = JSON.parse(response.body)['competences_fortes'][0]
+          expect(premiere_competence['picto'])
+            .to start_with('/assets/rapidite')
         end
       end
 

--- a/spec/requests/evaluations_spec.rb
+++ b/spec/requests/evaluations_spec.rb
@@ -76,12 +76,22 @@ describe 'Evaluation API', type: :request do
           create(:evenement_saisie_inventaire, :ok, situation: situation_inventaire,
                                                     evaluation: evaluation)
         end
+
         before { get "/api/evaluations/#{evaluation.id}" }
 
-        it do
+        it 'retourne les compétences triées par ordre de force décroissante' do
           attendues = [Competence::RAPIDITE, Competence::VIGILANCE_CONTROLE,
-                       Competence::ORGANISATION_METHODE]
-          expect(JSON.parse(response.body)['competences_fortes']).to eql(attendues.map(&:to_s))
+                       Competence::ORGANISATION_METHODE].map(&:to_s)
+          expect(JSON.parse(response.body)['competences_fortes'].pluck('id'))
+            .to eql(attendues)
+        end
+
+        it 'envoie aussi la descriptions des compétences' do
+          premiere_competence = JSON.parse(response.body)['competences_fortes'][0]
+          expect(premiere_competence['nom']).to eql("Vitesse d'exécution")
+          expect(premiere_competence['description'])
+            .to eql(I18n.t("#{Competence::RAPIDITE}.description",
+                           scope: 'admin.evaluations.restitution_competence'))
         end
       end
 

--- a/spec/requests/evaluations_spec.rb
+++ b/spec/requests/evaluations_spec.rb
@@ -97,7 +97,7 @@ describe 'Evaluation API', type: :request do
         it "envoie aussi l'URL du picto des compétences" do
           premiere_competence = JSON.parse(response.body)['competences_fortes'][0]
           expect(premiere_competence['picto'])
-            .to start_with('/assets/rapidite')
+            .to start_with('http://asset_host:port/assets/rapidite')
         end
       end
 


### PR DESCRIPTION
Cette PR permet d'éliminer la duplication des noms et description des compétences entre le serveur et le client. Elle fonctionne en duo avec la PR correspondante coté client. (https://github.com/betagouv/competences-pro/pull/592)

J'aurai bien aimé mocker I18N dans les tests. Est-ce possible ?