### PR TITLE
Affiche des statistique pour une campagne.

### DIFF
--- a/app/admin/campagne_stats.rb
+++ b/app/admin/campagne_stats.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+ActiveAdmin.register Evaluation, as: 'Campagne Stats' do
+  menu false
+  config.sort_order = 'created_at_desc'
+  includes :campagne
+
+  column_stats = proc do |situation, nom|
+    proc do
+      column "#{situation}_#{nom}".to_sym do |evaluation|
+        restitution(evaluation, situation)&.send(nom)
+      end
+    end
+  end
+
+  column_question = proc do |question|
+    proc do
+      column "bureau_#{question.libelle}".to_sym do |evaluation|
+        restitution(evaluation, 'questions')&.choix_repondu(question)&.type_choix
+      end
+    end
+  end
+
+  columns_stats = proc do
+    column :nom
+    column :created_at
+    column :efficience do |evaluation|
+      restitution_globale(evaluation).efficience
+    end
+    instance_eval(&column_stats.call('inventaire', :efficience))
+    instance_eval(&column_stats.call('inventaire', :temps_total))
+    instance_eval(&column_stats.call('inventaire', :nombre_ouverture_contenant))
+    instance_eval(&column_stats.call('inventaire', :nombre_essais_validation))
+    instance_eval(&column_stats.call('controle', :efficience))
+    instance_eval(&column_stats.call('controle', :nombre_bien_placees))
+    instance_eval(&column_stats.call('controle', :nombre_mal_placees))
+    instance_eval(&column_stats.call('controle', :nombre_non_triees))
+    instance_eval(&column_stats.call('tri', :efficience))
+    instance_eval(&column_stats.call('tri', :temps_total))
+    instance_eval(&column_stats.call('tri', :nombre_bien_placees))
+    instance_eval(&column_stats.call('tri', :nombre_mal_placees))
+    collection.first.campagne.questionnaire&.questions&.each do |question|
+      next unless question.is_a?(QuestionQcm)
+
+      instance_eval(&column_question.call(question))
+    end
+  end
+
+  csv do
+    instance_eval(&columns_stats)
+  end
+
+  index do
+    instance_eval(&columns_stats)
+  end
+
+  controller do
+    helper_method :restitution_globale, :restitution
+
+    def restitution_globale(evaluation)
+      @restitution_globale ||= {}
+      @restitution_globale[evaluation.id] ||= FabriqueRestitution.restitution_globale(evaluation)
+    end
+
+    def restitution(evaluation, nom_situation)
+      restitution_globale(evaluation).restitutions.find do |restitution|
+        restitution.situation.nom_technique == nom_situation
+      end
+    end
+  end
+end

--- a/app/admin/campagnes.rb
+++ b/app/admin/campagnes.rb
@@ -10,6 +10,10 @@ ActiveAdmin.register Campagne do
 
   includes :compte
 
+  action_item :stats, only: :show do
+    link_to 'Voir les stats', admin_campagne_stats_path(q: { campagne_id_eq: resource.id })
+  end
+
   index do
     selectable_column
     column :libelle

--- a/app/models/restitution/questions.rb
+++ b/app/models/restitution/questions.rb
@@ -28,6 +28,15 @@ module Restitution
       questions.select { |q| q.is_a?(QuestionQcm) }.count
     end
 
+    def choix_repondu(question)
+      question_et_reponse = questions_et_reponses.find do |question_reponse|
+        question_reponse[:question].id == question.id
+      end
+      return unless question_et_reponse
+
+      question_et_reponse[:question].choix.find(question_et_reponse[:reponse])
+    end
+
     def efficience
       question_qcm_repondue = questions_et_reponses.select { |q| q[:question].is_a?(QuestionQcm) }
       points_total = points_par_question(question_qcm_repondue).inject(0, :+)

--- a/spec/features/campagne_stats_spec.rb
+++ b/spec/features/campagne_stats_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe 'Admin - Campagne Stats', type: :feature do
+  let(:compte_organisation) { create :compte_organisation, email: 'orga@eva.fr' }
+  let!(:campagne) do
+    create :campagne, libelle: 'Rouen 30 mars', code: 'A5ROUEN', compte: compte_organisation
+  end
+  let!(:evaluation) { create :evaluation, nom: 'Roger', campagne: campagne }
+  let(:restitution_inventaire) do
+    double(
+      situation: Situation.new(nom_technique: 'inventaire'),
+      efficience: 2,
+      temps_total: 3,
+      nombre_ouverture_contenant: 4,
+      nombre_essais_validation: 5
+    )
+  end
+  let(:restitution_controle) do
+    double(
+      situation: Situation.new(nom_technique: 'controle'),
+      efficience: 6,
+      nombre_bien_placees: 7,
+      nombre_mal_placees: 8,
+      nombre_non_triees: 9
+    )
+  end
+  let(:restitution_tri) do
+    double(
+      situation: Situation.new(nom_technique: 'tri'),
+      efficience: 10,
+      temps_total: 11,
+      nombre_bien_placees: 12,
+      nombre_mal_placees: 13
+    )
+  end
+
+  describe 'index' do
+    before do
+      restitution_globale = double(efficience: 1,
+                                   restitutions: [
+                                     restitution_inventaire,
+                                     restitution_controle,
+                                     restitution_tri
+                                   ])
+      expect(restitution_globale).to receive(:efficience).and_return(1)
+      expect(FabriqueRestitution).to receive(:restitution_globale).and_return(restitution_globale)
+      connecte compte_organisation
+      visit admin_campagne_stats_path
+    end
+
+    it do
+      expect(page).to have_content 'Roger'
+      content = all(:css, 'tbody tr td').map(&:text)[2..]
+      expect(content).to eql(%w[1 2 3 4 5 6 7 8 9 10 11 12 13])
+    end
+  end
+end

--- a/spec/models/restitution/questions_spec.rb
+++ b/spec/models/restitution/questions_spec.rb
@@ -61,6 +61,33 @@ describe Restitution::Questions do
     end
   end
 
+  describe '#choix_reponse' do
+    let!(:choix_question1) do
+      create(:choix, intitule: 'bonne réponse', type_choix: 'bon',
+                     question_id: question1.id)
+    end
+
+    it 'retourne le choix répondu' do
+      evenements = [
+        create(:evenement_demarrage, evaluation: evaluation, situation: situation),
+        create(:evenement_reponse,
+               evaluation: evaluation,
+               situation: situation,
+               donnees: { question: question1.id, reponse: choix_question1.id })
+      ]
+      restitution = described_class.new(campagne, evenements)
+      expect(restitution.choix_repondu(question1)).to eql(choix_question1)
+    end
+
+    it "ne retourne rien si la question n'a pas été répondu" do
+      evenements = [
+        create(:evenement_demarrage, evaluation: evaluation, situation: situation)
+      ]
+      restitution = described_class.new(campagne, evenements)
+      expect(restitution.choix_repondu(question1)).to be_nil
+    end
+  end
+
   describe '#reponses' do
     it 'retourne toutes les réponses' do
       evenements = [


### PR DESCRIPTION
Affiche les résultats pour chaque évaluation de la campagne. Un lien permet d'accéder a une page qui affiche un tableau avec le résultat pour chaque situation. 

![Screenshot_2019-11-22 Test pour stats eva](https://user-images.githubusercontent.com/86659/69421048-4f5f9480-0d20-11ea-834a-94996626a2c3.png)

![Screenshot_2019-11-22 Campagne Stats eva](https://user-images.githubusercontent.com/86659/69421053-525a8500-0d20-11ea-8eef-8523978f0314.png)

Fix #240 