### PR TITLE
Spécifie un nom de fichier csv.

### DIFF
--- a/app/admin/campagne_stats.rb
+++ b/app/admin/campagne_stats.rb
@@ -67,5 +67,9 @@ ActiveAdmin.register Evaluation, as: 'Campagne Stats' do
         restitution.situation.nom_technique == nom_situation
       end
     end
+
+    def csv_filename
+      "campagne_stats_#{collection.first.campagne.code}.csv"
+    end
   end
 end


### PR DESCRIPTION
Pour différencier les noms des fichiers lors du téléchargement entre campagne.