### PR TITLE
Supprime l'onglet évaluation et redirige vers la campagne a la suppression

### DIFF
--- a/app/admin/evaluation.rb
+++ b/app/admin/evaluation.rb
@@ -1,17 +1,8 @@
 # frozen_string_literal: true
 
 ActiveAdmin.register Evaluation do
-  filter :campagne, collection: proc { evaluations_visibles }
-  filter :created_at
-  config.sort_order = 'created_at_desc'
-  includes :campagne
-
-  index do
-    column :nom
-    column :campagne
-    column :created_at
-    actions
-  end
+  menu false
+  actions :show, :destroy
 
   action_item :pdf, only: :show do
     link_to('Export PDF', {
@@ -30,7 +21,7 @@ ActiveAdmin.register Evaluation do
   end
 
   controller do
-    helper_method :evaluations_visibles, :restitution_globale
+    helper_method :restitution_globale
 
     def show
       show! do |format|
@@ -39,11 +30,11 @@ ActiveAdmin.register Evaluation do
       end
     end
 
-    private
-
-    def evaluations_visibles
-      current_compte.administrateur? ? Campagne.all : Campagne.where(compte: current_compte)
+    def destroy
+      destroy!(location: admin_campagne_path(resource.campagne))
     end
+
+    private
 
     def restitution_globale
       FabriqueRestitution.restitution_globale(resource, params[:parties_selectionnees])

--- a/spec/features/evaluation_spec.rb
+++ b/spec/features/evaluation_spec.rb
@@ -9,35 +9,6 @@ describe 'Admin - Evaluation', type: :feature do
     create :campagne, compte: Compte.first, libelle: 'Paris 2019', code: 'paris2019'
   end
 
-  context "en tant qu'organisation" do
-    let(:compte_rouen) { create :compte, role: 'organisation' }
-    let(:campagne_rouen) { create :campagne, compte: compte_rouen, libelle: 'Rouen 2019' }
-    let!(:evaluation) { create :evaluation, campagne: campagne_rouen }
-
-    let!(:mon_evaluation) { create :evaluation, campagne: ma_campagne, created_at: 3.days.ago }
-    let!(:mon_evaluation2) do
-      create :evaluation, campagne: ma_campagne, created_at: DateTime.now, nom: 'Jean'
-    end
-
-    it 'Je ne vois que les évaluations liées à mes campagnes' do
-      visit admin_evaluations_path
-      expect(page).to have_content 'Paris 2019'
-      expect(page).to_not have_content 'Rouen 2019'
-
-      within('#filters_sidebar_section') do
-        expect(page).to have_content 'Paris 2019'
-        expect(page).to_not have_content 'Rouen 2019'
-      end
-    end
-
-    it 'Trie les évaluations de la plus récentes à la plus vieille' do
-      visit admin_evaluations_path
-      within '.odd:first-of-type' do
-        expect(page).to have_content 'Jean'
-      end
-    end
-  end
-
   describe '#show' do
     let!(:mon_evaluation) { create :evaluation, campagne: ma_campagne, created_at: 3.days.ago }
     let(:situation) { build(:situation_inventaire) }
@@ -77,6 +48,7 @@ describe 'Admin - Evaluation', type: :feature do
     it do
       expect { click_on 'Supprimer' }.to(change { Evaluation.count }
                                      .and(change { Evenement.count }))
+      expect(page.current_url).to eql(admin_campagne_url(ma_campagne))
     end
   end
 end


### PR DESCRIPTION
Pour limiter le nombre d'onglets dans l'admin et avoir un seul chemin de navigation, j'ai supprimé la vue index des évaluations. Et à la suppression d'une évaluation, on redirige vers la campagne.