### PR TITLE
Spécifie l'ordre des événements d'une partie.

### DIFF
--- a/app/models/partie.rb
+++ b/app/models/partie.rb
@@ -3,7 +3,7 @@
 class Partie < ApplicationRecord
   belongs_to :evaluation
   belongs_to :situation
-  has_many :evenements, foreign_key: :session_id, primary_key: :session_id
+  has_many :evenements, -> { order(:date) }, foreign_key: :session_id, primary_key: :session_id
 
   validates :session_id, presence: true
 

--- a/spec/models/partie_spec.rb
+++ b/spec/models/partie_spec.rb
@@ -10,6 +10,9 @@ describe Partie do
   it { should belong_to(:situation) }
 
   it do
-    should have_many(:evenements).with_primary_key(:session_id).with_foreign_key(:session_id)
+    should have_many(:evenements)
+      .order(:date)
+      .with_primary_key(:session_id)
+      .with_foreign_key(:session_id)
   end
 end


### PR DESCRIPTION
Pour s'assurer que l'on prend les événements dans leur ordre de création.