### PR TITLE
Empêche la suppression de campagne avec des évaluations

### DIFF
--- a/app/admin/campagnes.rb
+++ b/app/admin/campagnes.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 ActiveAdmin.register Campagne do
+  config.batch_actions = false
   permit_params :libelle, :code, :questionnaire_id, :compte, :compte_id,
                 situations_configurations_attributes: %i[id situation_id _destroy]
 

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -18,7 +18,10 @@ class Ability
 
   def droit_campagne(compte)
     can :create, Campagne
-    can :manage, Campagne, compte_id: compte.id
+    can %i[create update read], Campagne, compte_id: compte.id
+    can :destroy, Campagne do |c|
+      c.evaluations.count.zero?
+    end
   end
 
   def droit_evaluation(compte)

--- a/app/models/campagne.rb
+++ b/app/models/campagne.rb
@@ -2,7 +2,7 @@
 
 class Campagne < ApplicationRecord
   has_many :evaluations, -> { order(created_at: :desc) }
-  has_many :situations_configurations, -> { order(position: :asc) }
+  has_many :situations_configurations, -> { order(position: :asc) }, dependent: :destroy
   has_many :situations, through: :situations_configurations
   belongs_to :questionnaire, optional: true
   belongs_to :compte

--- a/spec/factories/situation_configuration.rb
+++ b/spec/factories/situation_configuration.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :situation_configuration do
+    campagne
+    situation
+  end
+end

--- a/spec/integrations/ability_spec.rb
+++ b/spec/integrations/ability_spec.rb
@@ -32,7 +32,7 @@ describe Ability do
 
   context 'Compte organisation' do
     let(:compte)                    { compte_organisation }
-    let(:campagne_organisation)     { create :campagne, compte: compte }
+    let!(:campagne_organisation)    { create :campagne, compte: compte }
     let(:campagne_administrateur)   { create :campagne, compte: compte_administrateur }
     let(:evaluation_administrateur) { create :evaluation, campagne: campagne_administrateur }
     let(:evaluation_organisation)   { create :evaluation, campagne: campagne_organisation }
@@ -47,6 +47,10 @@ describe Ability do
     let!(:partie_organisation) do
       create :partie, session_id: 'test2', evaluation: evaluation_organisation,
                       situation: situation, evenements: [evenement_organisation]
+    end
+
+    it 'avec une campagne qui a des évaluations' do
+      is_expected.to_not be_able_to(:destroy, campagne_organisation)
     end
 
     it { is_expected.to_not be_able_to(:manage, :all) }
@@ -69,7 +73,8 @@ describe Ability do
     it { is_expected.to be_able_to(%i[read destroy], evaluation_organisation) }
     it { is_expected.to be_able_to(:read, evenement_organisation) }
     it { is_expected.to be_able_to(:create, Campagne.new) }
-    it { is_expected.to be_able_to(:manage, Campagne.new(compte: compte)) }
+    it { is_expected.to be_able_to(%i[create update read], Campagne.new(compte: compte)) }
+    it { is_expected.to be_able_to(:destroy, Campagne.new(compte: compte)) }
     it { is_expected.to be_able_to(:read, Questionnaire.new) }
     it { is_expected.to be_able_to(:read, Situation.new) }
     it { is_expected.to be_able_to(:manage, Restitution::Base.new(campagne_organisation, nil)) }

--- a/spec/integrations/campagne_spec.rb
+++ b/spec/integrations/campagne_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Campagne, type: :integration do
+  context 'pour une campagne sans évaluation' do
+    let(:campagne) { create :campagne }
+    let(:situation) { create :situation_inventaire }
+    let!(:situations_configurations) do
+      create :situation_configuration, campagne_id: campagne.id, situation: situation
+    end
+
+    it 'supprime les dépendances' do
+      expect do
+        campagne.destroy
+      end.to change { described_class.count }.by(-1)
+                                             .and change { SituationConfiguration.count }.by(-1)
+    end
+  end
+end


### PR DESCRIPTION
Cette PR vise à corriger l'erreur en screenshot ci-dessous, en effet elle :

1. Empêche de supprimer une `Campagne` qui a des évaluations.

2. Supprime les `SituationConfiguration` associées à la `Campagne`.


<img width="1424" alt="Capture d’écran 2019-12-10 à 12 46 31" src="https://user-images.githubusercontent.com/20596535/70527176-97b5e980-1b4b-11ea-817d-b6d385fe54ab.png">
