### PR TITLE
encapsule les évaluations dans les campagnes en admin

### DIFF
--- a/app/admin/campagnes.rb
+++ b/app/admin/campagnes.rb
@@ -39,14 +39,6 @@ ActiveAdmin.register Campagne do
     f.actions
   end
 
-  sidebar 'Voir...', only: :show do
-    ul do
-      li link_to 'Les stats', admin_campagne_stats_path(q: { campagne_id_eq: resource.id })
-      li link_to "#{resource.nombre_evaluations} évaluations",
-                 admin_campagne_evaluations_path(resource)
-    end
-  end
-
   controller do
     def create
       params[:campagne][:compte_id] ||= current_compte.id

--- a/app/admin/campagnes.rb
+++ b/app/admin/campagnes.rb
@@ -11,10 +11,6 @@ ActiveAdmin.register Campagne do
 
   includes :compte
 
-  action_item :stats, only: :show do
-    link_to 'Voir les stats', admin_campagne_stats_path(q: { campagne_id_eq: resource.id })
-  end
-
   index do
     selectable_column
     column :libelle
@@ -41,6 +37,14 @@ ActiveAdmin.register Campagne do
       end
     end
     f.actions
+  end
+
+  sidebar 'Voir...', only: :show do
+    ul do
+      li link_to 'Les stats', admin_campagne_stats_path(q: { campagne_id_eq: resource.id })
+      li link_to "#{resource.nombre_evaluations} évaluations",
+                 admin_campagne_evaluations_path(resource)
+    end
   end
 
   controller do

--- a/app/admin/evaluation.rb
+++ b/app/admin/evaluation.rb
@@ -1,8 +1,11 @@
 # frozen_string_literal: true
 
 ActiveAdmin.register Evaluation do
-  menu false
-  actions :show, :destroy
+  actions :index, :show, :destroy
+  belongs_to :campagne
+
+  filter :nom
+  filter :created_at
 
   action_item :pdf, only: :show do
     link_to('Export PDF', {
@@ -10,6 +13,13 @@ ActiveAdmin.register Evaluation do
               format: :pdf
             },
             target: '_blank')
+  end
+
+  index do
+    selectable_column
+    column :nom
+    column :created_at
+    actions
   end
 
   show do

--- a/app/admin/restitutions.rb
+++ b/app/admin/restitutions.rb
@@ -17,8 +17,9 @@ ActiveAdmin.register Partie, as: 'Restitutions' do
 
     def destroy
       evaluation = resource.evaluation
+      campagne = resource.campagne
       resource.supprimer
-      redirect_to admin_evaluation_path(evaluation)
+      redirect_to admin_campagne_evaluation_path(campagne, evaluation)
     end
   end
 

--- a/app/views/admin/campagnes/_show.html.arb
+++ b/app/views/admin/campagnes/_show.html.arb
@@ -16,3 +16,17 @@ panel 'Configuration' do
     column :situation
   end
 end
+
+columns do
+  column do
+    panel 'Évaluations' do
+      link_to "Consulter les #{resource.nombre_evaluations} évaluations",
+              admin_campagne_evaluations_path(resource)
+    end
+  end
+  column do
+    panel 'Statistiques' do
+      link_to 'Consulter les stats', admin_campagne_stats_path(q: { campagne_id_eq: resource.id })
+    end
+  end
+end

--- a/app/views/admin/campagnes/_show.html.arb
+++ b/app/views/admin/campagnes/_show.html.arb
@@ -16,13 +16,3 @@ panel 'Configuration' do
     column :situation
   end
 end
-
-panel "Évaluations (#{campagne.nombre_evaluations})" do
-  table_for campagne.evaluations do
-    column :nom do |evaluation|
-      link_to evaluation.nom,
-              admin_evaluation_path(evaluation)
-    end
-    column :created_at
-  end
-end

--- a/spec/features/campagne_spec.rb
+++ b/spec/features/campagne_spec.rb
@@ -114,6 +114,6 @@ describe 'Admin - Campagne', type: :feature do
       campagne.situations_configurations.create! situation: situation
       visit admin_campagne_path campagne
     end
-    it { expect(page).to have_content 'Roger' }
+    it { expect(page).to have_content 'Inventaire' }
   end
 end

--- a/spec/features/evaluation_spec.rb
+++ b/spec/features/evaluation_spec.rb
@@ -26,7 +26,7 @@ describe 'Admin - Evaluation', type: :feature do
     end
 
     it "affiche l'évaluation" do
-      visit admin_evaluation_path(mon_evaluation)
+      visit admin_campagne_evaluation_path(ma_campagne, mon_evaluation)
       expect(page).to have_content 'Roger'
     end
 
@@ -34,7 +34,7 @@ describe 'Admin - Evaluation', type: :feature do
       competences = [{ Competence::ORGANISATION_METHODE => Competence::NIVEAU_4 }]
       expect(restitution_globale).to receive(:niveaux_competences).and_return(competences)
       expect(FabriqueRestitution).to receive(:restitution_globale).and_return(restitution_globale)
-      visit admin_evaluation_path(mon_evaluation, format: :pdf)
+      visit admin_campagne_evaluation_path(ma_campagne, mon_evaluation, format: :pdf)
       path = page.save_page
 
       reader = PDF::Reader.new(path)
@@ -49,7 +49,7 @@ describe 'Admin - Evaluation', type: :feature do
       create :partie, situation: situation, evaluation: evaluation, evenements: [evenement]
     end
     let(:evenement) { build :evenement }
-    before { visit admin_evaluation_path(evaluation) }
+    before { visit admin_campagne_evaluation_path(ma_campagne, evaluation) }
 
     it do
       expect { click_on 'Supprimer' }.to(change { Evaluation.count }


### PR DESCRIPTION
déplace les évaluations dans une page à part, ce qui permet de ne plus avoir de fil d'ariane cassé et d'avoir des filtres

![Capture d’écran 2019-12-11 à 13 09 07](https://user-images.githubusercontent.com/28393/70620458-a538a580-1c17-11ea-884a-dc5a42060dbc.png)
![Capture d’écran 2019-12-11 à 13 09 15](https://user-images.githubusercontent.com/28393/70620467-aa95f000-1c17-11ea-9760-cbb5c3d0a8d0.png)
![Capture d’écran 2019-12-11 à 13 09 26](https://user-images.githubusercontent.com/28393/70620468-ab2e8680-1c17-11ea-9298-361b97d5b490.png)


fix #266 