### PR TITLE
Corrige l'affichage de l'attention visuo spatiale.

### DIFF
--- a/app/views/admin/restitutions/_restitution_securite.html.arb
+++ b/app/views/admin/restitutions/_restitution_securite.html.arb
@@ -34,7 +34,9 @@ panel t('.restitution_securite') do
       Time.at(temps).strftime('%M:%S') if temps.present?
     end
     row t('.attention_visuo_spatiale') do |_, r|
-      t(r.attention_visuo_spatiale, scope: 'admin.evaluations.restitution_competence')
+      if r.attention_visuo_spatiale.present?
+        t(r.attention_visuo_spatiale, scope: 'admin.evaluations.restitution_competence')
+      end
     end
     row t('.retours_zones_sans_danger') do |(_, r)|
       r.nombre_reouverture_zone_sans_danger


### PR DESCRIPTION
En production, le fallback d'i18n affichait 'Restitution Competence'.

Voila l'affichage précédemment en mode production:

![Screenshot_2019-12-11 Roger - Sécurité eva(2)](https://user-images.githubusercontent.com/86659/70630879-97d9e600-1c2c-11ea-8ae4-0abef992218b.png)

Et l'affichage après:

![Screenshot_2019-12-11 Roger - Sécurité eva(3)](https://user-images.githubusercontent.com/86659/70630919-a7592f00-1c2c-11ea-9ae1-7c47a898e3da.png)
